### PR TITLE
Fix lint issues and standardize imports

### DIFF
--- a/parakeet_nemo_asr_rocm/chunking/chunker.py
+++ b/parakeet_nemo_asr_rocm/chunking/chunker.py
@@ -38,6 +38,7 @@ def segment_waveform(
     Returns:
         A list of ``(segment, offset_sec)`` tuples where ``offset_sec`` is the
         starting position of the segment relative to the original audio.
+
     """
     if chunk_len_sec <= 0 or wav.size == 0:
         return [(wav, 0.0)]

--- a/parakeet_nemo_asr_rocm/chunking/merge.py
+++ b/parakeet_nemo_asr_rocm/chunking/merge.py
@@ -63,6 +63,7 @@ def merge_longest_contiguous(
         Chronologically sorted token lists from successive chunks.
     overlap_duration
         How many **seconds** of audio overlapped between the two parent chunks.
+
     """
     if not a:
         return b.copy()

--- a/parakeet_nemo_asr_rocm/cli.py
+++ b/parakeet_nemo_asr_rocm/cli.py
@@ -1,10 +1,8 @@
-"""
-This module provides the command-line interface for the Parakeet-NEMO ASR application,
-built using the Typer library.
+"""Command-line interface for the Parakeet-NeMo ASR application using Typer.
 
-It is designed to replace the older `argparse`-based CLI with a more robust and
-user-friendly interface that supports subcommands, rich help messages, and better
-argument handling.
+Replaces the older `argparse`-based CLI with a more robust and user-friendly
+interface that supports subcommands, rich help messages, and improved argument
+handling.
 
 Features:
 - `transcribe` command for running ASR on audio files.
@@ -215,9 +213,7 @@ def transcribe(
         ),
     ] = False,
 ):
-    """
-    Transcribe one or more audio files using the specified NVIDIA NeMo Parakeet model.
-    """
+    """Transcribe audio files using the specified NVIDIA NeMo Parakeet model."""
     # Delegation to heavy implementation (lazy import)
     from importlib import import_module  # pylint: disable=import-outside-toplevel
 

--- a/parakeet_nemo_asr_rocm/formatting/__init__.py
+++ b/parakeet_nemo_asr_rocm/formatting/__init__.py
@@ -1,8 +1,7 @@
-"""
-This module provides a registry of output formatters for transcriptions.
+"""Registry of output formatters for transcriptions.
 
-It allows for easy extension with new formats by adding a new formatter function
-and registering it in the `FORMATTERS` dictionary.
+Allows easy extension with new formats by adding a formatter function and
+registering it in the ``FORMATTERS`` dictionary.
 """
 
 from typing import Callable, Dict
@@ -30,8 +29,7 @@ FORMATTERS: Dict[str, Callable[[AlignedResult], str]] = {
 
 
 def get_formatter(format_name: str) -> Callable[[AlignedResult], str]:
-    """
-    Retrieves the formatter function for a given format name.
+    """Retrieve the formatter function for a given format name.
 
     Args:
         format_name: The name of the format (e.g., 'txt', 'json').
@@ -41,6 +39,7 @@ def get_formatter(format_name: str) -> Callable[[AlignedResult], str]:
 
     Raises:
         ValueError: If the format_name is not supported.
+
     """
     formatter = FORMATTERS.get(format_name.lower())
     if not formatter:

--- a/parakeet_nemo_asr_rocm/formatting/_json.py
+++ b/parakeet_nemo_asr_rocm/formatting/_json.py
@@ -1,18 +1,16 @@
-"""
-Formatter for JSON (.json) output.
-"""
+"""Formatter for JSON (.json) output."""
 
 from parakeet_nemo_asr_rocm.timestamps.models import AlignedResult
 
 
 def to_json(result: AlignedResult) -> str:
-    """
-    Converts AlignedResult to a JSON string.
+    """Convert an ``AlignedResult`` to a JSON string.
 
     Args:
         result: The AlignedResult object.
 
     Returns:
         A JSON string representation of the AlignedResult.
+
     """
     return result.model_dump_json(indent=2)

--- a/parakeet_nemo_asr_rocm/formatting/_jsonl.py
+++ b/parakeet_nemo_asr_rocm/formatting/_jsonl.py
@@ -1,6 +1,7 @@
-"""
-Formatter for JSON Lines (.jsonl) output.
-Each line contains a JSON object representing a single *Segment* in the aligned result.
+"""Formatter for JSON Lines (.jsonl) output.
+
+Each line contains a JSON object representing a single *Segment* in the aligned
+result.
 """
 
 from __future__ import annotations

--- a/parakeet_nemo_asr_rocm/formatting/_srt.py
+++ b/parakeet_nemo_asr_rocm/formatting/_srt.py
@@ -1,6 +1,4 @@
-"""
-Formatter for SubRip Subtitle format (.srt).
-"""
+"""Formatter for SubRip Subtitle format (.srt)."""
 
 import math
 
@@ -8,7 +6,7 @@ from parakeet_nemo_asr_rocm.timestamps.models import AlignedResult
 
 
 def _format_timestamp(seconds: float) -> str:
-    """Converts seconds to SRT timestamp format (HH:MM:SS,ms)."""
+    """Convert seconds to SRT timestamp format (HH:MM:SS,ms)."""
     assert seconds >= 0, "non-negative timestamp required"
     m, s = divmod(seconds, 60)
     h, m = divmod(m, 60)
@@ -16,14 +14,15 @@ def _format_timestamp(seconds: float) -> str:
 
 
 def to_srt(result: AlignedResult, highlight_words: bool = False) -> str:
-    """
-    Converts AlignedResult to an SRT formatted string.
+    """Convert an ``AlignedResult`` to an SRT formatted string.
 
     Args:
         result: The AlignedResult object containing transcription segments.
+        highlight_words: If ``True``, wrap each word in ``<b>`` tags for emphasis.
 
     Returns:
         A string in SRT format.
+
     """
     srt_lines = []
     for i, segment in enumerate(result.segments, start=1):

--- a/parakeet_nemo_asr_rocm/formatting/_txt.py
+++ b/parakeet_nemo_asr_rocm/formatting/_txt.py
@@ -1,18 +1,16 @@
-"""
-Formatter for plain text (.txt) output.
-"""
+"""Formatter for plain text (.txt) output."""
 
 from parakeet_nemo_asr_rocm.timestamps.models import AlignedResult
 
 
 def to_txt(result: AlignedResult) -> str:
-    """
-    Converts AlignedResult to a plain text string.
+    """Convert an ``AlignedResult`` to a plain text string.
 
     Args:
         result: The AlignedResult object containing transcription segments.
 
     Returns:
         A single string containing the concatenated text of all segments.
+
     """
     return " ".join([segment.text for segment in result.segments])

--- a/parakeet_nemo_asr_rocm/formatting/_vtt.py
+++ b/parakeet_nemo_asr_rocm/formatting/_vtt.py
@@ -1,6 +1,4 @@
-"""
-Formatter for Web Video Text Tracks format (.vtt).
-"""
+"""Formatter for Web Video Text Tracks format (.vtt)."""
 
 import math
 
@@ -8,7 +6,7 @@ from parakeet_nemo_asr_rocm.timestamps.models import AlignedResult
 
 
 def _format_timestamp(seconds: float) -> str:
-    """Converts seconds to VTT timestamp format (HH:MM:SS.ms)."""
+    """Convert seconds to VTT timestamp format (HH:MM:SS.ms)."""
     assert seconds >= 0, "non-negative timestamp required"
     m, s = divmod(seconds, 60)
     h, m = divmod(m, 60)
@@ -16,14 +14,15 @@ def _format_timestamp(seconds: float) -> str:
 
 
 def to_vtt(result: AlignedResult, highlight_words: bool = False) -> str:
-    """
-    Converts AlignedResult to a VTT formatted string.
+    """Convert an ``AlignedResult`` to a VTT formatted string.
 
     Args:
         result: The AlignedResult object containing transcription segments.
+        highlight_words: If ``True``, surround each word with ``<c.highlight>`` tags.
 
     Returns:
         A string in VTT format.
+
     """
     vtt_lines = ["WEBVTT", ""]
     for segment in result.segments:

--- a/parakeet_nemo_asr_rocm/formatting/refine.py
+++ b/parakeet_nemo_asr_rocm/formatting/refine.py
@@ -90,6 +90,20 @@ class SubtitleRefiner:
         max_line_chars: int = MAX_LINE_CHARS,
         max_lines_per_block: int = getattr(_c, "MAX_LINES_PER_BLOCK", 2),
     ) -> None:
+        """Initialise the refiner with limits for caption readability.
+
+        Args:
+            max_cps: Maximum characters per second.
+            min_dur: Minimum duration of a caption in seconds.
+            gap_frames: Minimum gap between captions in frames.
+            fps: Frames per second of the video.
+            max_line_chars: Maximum characters per subtitle line.
+            max_lines_per_block: Maximum lines per subtitle block.
+
+        Returns:
+            None.
+
+        """
         self.max_cps = max_cps
         self.min_dur = min_dur
         self.gap = gap_frames / fps

--- a/parakeet_nemo_asr_rocm/models/parakeet.py
+++ b/parakeet_nemo_asr_rocm/models/parakeet.py
@@ -14,7 +14,7 @@ DEFAULT_MODEL_NAME = "nvidia/parakeet-tdt-0.6b-v2"
 
 
 def _load_model(model_name: str) -> nemo_asr.models.ASRModel:
-    """Loads and initializes the Parakeet ASR model.
+    """Load and initialize the Parakeet ASR model.
 
     This function downloads the pre-trained model from NVIDIA's NGC, sets it
     to evaluation mode, and moves it to the appropriate device (GPU if
@@ -22,6 +22,7 @@ def _load_model(model_name: str) -> nemo_asr.models.ASRModel:
 
     Returns:
         The initialized ASRModel instance.
+
     """
     device = "cuda" if torch.cuda.is_available() else "cpu"
     model = nemo_asr.models.ASRModel.from_pretrained(model_name).eval().to(device)
@@ -40,5 +41,6 @@ def get_model(
 
     Returns:
         The cached ASRModel instance, moved to GPU if available.
+
     """
     return _load_model(model_name)

--- a/parakeet_nemo_asr_rocm/timestamps/adapt.py
+++ b/parakeet_nemo_asr_rocm/timestamps/adapt.py
@@ -1,9 +1,7 @@
-"""
-This module provides functions for adapting NeMo's timestamped ASR output
-into a standardized format.
+"""Functions for adapting NeMo's timestamped ASR output into a standard format.
 
-The goal is to create a common data structure (`AlignedResult`) that can be used
-by various formatters (e.g., SRT, VTT, JSON) regardless of the specifics of the
+The goal is to create a common data structure (``AlignedResult``) usable by
+various formatters (e.g., SRT, VTT, JSON) regardless of the specifics of the
 ASR model's output.
 """
 
@@ -29,7 +27,7 @@ from parakeet_nemo_asr_rocm.utils.constant import (
 def adapt_nemo_hypotheses(
     hypotheses: List[Hypothesis], model: ASRModel, time_stride: float | None = None
 ) -> AlignedResult:
-    """Converts a list of NeMo Hypothesis objects into a standardized AlignedResult."""
+    """Convert a list of NeMo Hypothesis objects into a standard ``AlignedResult``."""
     word_timestamps = get_word_timestamps(hypotheses, model, time_stride)
 
     if not word_timestamps:

--- a/parakeet_nemo_asr_rocm/timestamps/segmentation.py
+++ b/parakeet_nemo_asr_rocm/timestamps/segmentation.py
@@ -1,10 +1,9 @@
-"""Utilities for converting word-level timestamps into readability-compliant
-subtitle segments.
+"""Utilities for converting word-level timestamps into readability-compliant subtitle segments.
 
-This module implements the main sentence/clause segmentation algorithm that
-was previously embedded in `timestamps/adapt.py`. It now lives in a dedicated
-module so that the logic can be unit-tested in isolation and imported by
-both the NeMo adaptor and formatting layers.
+This module implements the main sentence/clause segmentation algorithm that was
+previously embedded in ``timestamps/adapt.py``. It now lives in a dedicated
+module so that the logic can be unit-tested in isolation and imported by both
+the NeMo adaptor and formatting layers.
 """
 
 from __future__ import annotations
@@ -265,7 +264,6 @@ def split_lines(text: str) -> str:
     3. Fall back to a greedy split just before the limit if no balanced break
        fulfils the minimum-length requirement.
     """
-
     if len(text) <= MAX_LINE_CHARS:
         return text
 
@@ -380,7 +378,6 @@ def segment_words(words: List[Word]) -> List[Segment]:
     4. Adjacent sentences are merged while combined block still satisfies
        all limits.
     """
-
     if not words:
         return []
 

--- a/parakeet_nemo_asr_rocm/timestamps/word_timestamps.py
+++ b/parakeet_nemo_asr_rocm/timestamps/word_timestamps.py
@@ -1,6 +1,4 @@
-"""
-Module for extracting word-level timestamps from NeMo's model outputs.
-"""
+"""Utilities for extracting word-level timestamps from NeMo ASR hypotheses."""
 
 from typing import List
 
@@ -15,8 +13,7 @@ def get_word_timestamps(
     model: ASRModel,
     time_stride: float | None = None,
 ) -> List[Word]:
-    """
-    Calculates word-level timestamps from a Transducer model's hypotheses.
+    """Calculate word-level timestamps from a Transducer model's hypotheses.
 
     Args:
         hypotheses: A list of Hypothesis objects from NeMo.
@@ -25,6 +22,7 @@ def get_word_timestamps(
 
     Returns:
         A list of Word objects with calculated timestamps.
+
     """
     all_words: List[Word] = []
     # SentencePiece-based tokenizers (used by NeMo ASR models) encode the beginning

--- a/parakeet_nemo_asr_rocm/transcribe.py
+++ b/parakeet_nemo_asr_rocm/transcribe.py
@@ -47,6 +47,7 @@ def _transcribe_chunks(
         A tuple of (texts, words_list) where:
         - texts: List of transcribed text strings
         - words_list: List of Word objects with timing information
+
     """
     # Separate chunks and their offsets
     chunk_audio = [chunk for chunk, _ in chunks]
@@ -180,7 +181,6 @@ def cli_transcribe(
     instantly, while the full dependency graph is only initialised when the user
     actually runs the `transcribe` command.
     """
-
     # ---------------------------------------------------------------------
     # Early logging configuration based on --verbose flag
     # ---------------------------------------------------------------------

--- a/parakeet_nemo_asr_rocm/utils/audio_io.py
+++ b/parakeet_nemo_asr_rocm/utils/audio_io.py
@@ -33,6 +33,7 @@ def _load_with_ffmpeg(path: Path | str, target_sr: int) -> Tuple[np.ndarray, int
 
     Returns:
         Tuple[num_samples(float32), sample_rate]
+
     """
     if shutil.which("ffmpeg") is None:
         raise RuntimeError("FFmpeg is not installed or not in PATH.")
@@ -75,6 +76,7 @@ def _load_with_pydub(path: Path | str) -> Tuple[np.ndarray, int]:
         A tuple containing:
         - data: Mono float32 waveform in range [-1, 1].
         - sr: Native sample rate of the decoded audio.
+
     """
     # pydub loads into AudioSegment (16-bit PCM by default)
     seg: AudioSegment = AudioSegment.from_file(path)
@@ -101,6 +103,7 @@ def load_audio(
         A tuple containing:
         - audio: A 1-D float32 waveform in the range [-1, 1].
         - sr: The sample rate after resampling (equal to `target_sr`).
+
     """
     # Loading strategy order:
     # 1. If FORCE_FFMPEG, try direct FFmpeg pipe first.

--- a/parakeet_nemo_asr_rocm/utils/constant.py
+++ b/parakeet_nemo_asr_rocm/utils/constant.py
@@ -93,4 +93,6 @@ TRANSFORMERS_VERBOSITY: Final[str] = os.getenv("TRANSFORMERS_VERBOSITY", "ERROR"
 # Gradio configuration
 GRADIO_SERVER_PORT: Final[int] = int(os.getenv("GRADIO_SERVER_PORT", "7861"))
 GRADIO_SERVER_NAME: Final[str] = os.getenv("GRADIO_SERVER_NAME", "0.0.0.0")
-GRADIO_ANALYTICS_ENABLED: Final[bool] = os.getenv("GRADIO_ANALYTICS_ENABLED", "False").lower() == "true"
+GRADIO_ANALYTICS_ENABLED: Final[bool] = (
+    os.getenv("GRADIO_ANALYTICS_ENABLED", "False").lower() == "true"
+)

--- a/parakeet_nemo_asr_rocm/utils/env_loader.py
+++ b/parakeet_nemo_asr_rocm/utils/env_loader.py
@@ -44,6 +44,7 @@ def load_project_env(force: bool = False) -> None:
     Args:
         force: If True, bypasses the cache and forces a reload of the
             environment file. Defaults to False.
+
     """
     if force:
         load_project_env.cache_clear()  # type: ignore[attr-defined]

--- a/parakeet_nemo_asr_rocm/utils/file_utils.py
+++ b/parakeet_nemo_asr_rocm/utils/file_utils.py
@@ -1,5 +1,4 @@
-"""File utilities for handling output file naming, overwrite protection, and
-helper functions for resolving audio input paths / patterns.
+"""File utilities for output file naming, overwrite protection, and audio path resolution.
 
 All functions are type-hinted and documented. The module exposes:
 • `get_unique_filename` – unchanged
@@ -12,7 +11,6 @@ from __future__ import annotations
 import pathlib
 from glob import glob
 from typing import Iterable, List, Sequence, Union
-
 
 PathLike = Union[str, pathlib.Path]
 
@@ -67,6 +65,7 @@ def get_unique_filename(
 
     Returns:
         A pathlib.Path that is guaranteed not to exist (unless overwrite=True).
+
     """
     path = pathlib.Path(base_path)
 
@@ -96,6 +95,7 @@ def _is_audio_file(
         path: File path to test.
         exts: Optional iterable of file extensions to accept; defaults to
             :data:`AUDIO_EXTENSIONS`.
+
     """
     _exts = set(ext.lower() for ext in (exts or AUDIO_EXTENSIONS))
     return path.is_file() and path.suffix.lower() in _exts
@@ -127,8 +127,8 @@ def resolve_input_paths(
     Returns:
         Sorted list (by insertion order, duplicates removed) of ``pathlib.Path``
         objects that exist and match the extension filter.
-    """
 
+    """
     if isinstance(patterns, (str, pathlib.Path)):
         patterns = [patterns]
 

--- a/parakeet_nemo_asr_rocm/utils/watch.py
+++ b/parakeet_nemo_asr_rocm/utils/watch.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 import signal
 import sys
 import time
+from pathlib import Path
 from types import FrameType
 from typing import Callable, Iterable, List, Sequence
-from pathlib import Path
 
 from parakeet_nemo_asr_rocm.utils.file_utils import (
     AUDIO_EXTENSIONS,
@@ -38,6 +38,7 @@ def _default_sig_handler(signum: int, _frame: FrameType | None) -> None:  # noqa
     Args:
         signum: Received POSIX signal number (unused).
         _frame: Current stack frame (unused).
+
     """
     print("\n[watch] Stopping…")
     sys.exit(0)
@@ -59,6 +60,7 @@ def _needs_transcription(
 
     Returns:
         ``True`` if no output file exists for *path* yet, ``False`` otherwise.
+
     """
     target_name = output_template.format(
         parent=path.parent.name,
@@ -102,6 +104,7 @@ def watch_and_transcribe(
 
     Returns:
         None. This function blocks indefinitely until interrupted.
+
     """
     print(
         f"[watch] Monitoring {', '.join(map(str, patterns))} …  (Press Ctrl+C to stop)"

--- a/scripts/parakeet_gradio_app.py
+++ b/scripts/parakeet_gradio_app.py
@@ -26,10 +26,12 @@ default web browser.
 """
 
 import pathlib
+
 import gradio as gr
-from parakeet_nemo_asr_rocm.utils import constant
-from parakeet_nemo_asr_rocm.transcribe import cli_transcribe
+
 from parakeet_nemo_asr_rocm.models.parakeet import DEFAULT_MODEL_NAME
+from parakeet_nemo_asr_rocm.transcribe import cli_transcribe
+from parakeet_nemo_asr_rocm.utils import constant
 
 
 def enforce_precision(fp16: bool, fp32: bool) -> tuple[bool, bool]:
@@ -349,7 +351,7 @@ def build_ui() -> gr.Blocks:
         # Main action and output
         with gr.Row():
             transcribe_btn = gr.Button("Transcribe", variant="primary", size="lg")
-            status = gr.Markdown("", visible=False)
+            _status = gr.Markdown("", visible=False)
         output_files = gr.Files(label="Transcription Outputs", interactive=False)
 
         # Inject custom JS for theme persistence

--- a/scripts/parakeet_streamlit_app.py
+++ b/scripts/parakeet_streamlit_app.py
@@ -33,9 +33,9 @@ from typing import List, Tuple
 
 import streamlit as st
 
-from parakeet_nemo_asr_rocm.utils import constant
-from parakeet_nemo_asr_rocm.transcribe import cli_transcribe
 from parakeet_nemo_asr_rocm.models.parakeet import DEFAULT_MODEL_NAME
+from parakeet_nemo_asr_rocm.transcribe import cli_transcribe
+from parakeet_nemo_asr_rocm.utils import constant
 
 
 def enforce_precision(fp16: bool, fp32: bool) -> Tuple[bool, bool]:


### PR DESCRIPTION
## Summary
- refine module and function docstrings across the package to match project style
- document `highlight_words` and rewrite formatter docstrings for SRT and VTT outputs
- clarify top-level descriptions for CLI, timestamp adapters, and file utilities

## Testing
- `bash scripts/clean_codebase.sh`
- `pdm run ruff check parakeet_nemo_asr_rocm --select D`
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893a2d911e8832b8692032e6d2908b2