### PR TITLE
fix 🐛: Fix CIFS mount 'not writable' false negative

### DIFF
--- a/parakeet_rocm/benchmarks/collector.py
+++ b/parakeet_rocm/benchmarks/collector.py
@@ -30,6 +30,7 @@ import threading
 from datetime import datetime, timezone
 from typing import Any, Protocol
 
+from parakeet_rocm.utils.file_utils import ensure_dir_writable
 from parakeet_rocm.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -278,8 +279,7 @@ class BenchmarkCollector:
             audio_path: Path to audio file being transcribed.
             task: Transcription task type (e.g., "transcribe", "translate").
         """
-        self.output_dir = output_dir
-        self.output_dir.mkdir(parents=True, exist_ok=True)
+        self.output_dir = ensure_dir_writable(output_dir, label="Benchmark directory")
 
         # Generate slug: YYYYMMDD_HHMMSS_<name>
         now = datetime.now(tz=timezone.utc)

--- a/parakeet_rocm/cli.py
+++ b/parakeet_rocm/cli.py
@@ -142,6 +142,13 @@ def _setup_watch_mode(
         fp16 (bool): Enable FP16 precision.
         allow_unsafe_filenames (bool): Use relaxed filename validation.
     """
+    # Validate output directory is writable before starting the watcher
+    from parakeet_rocm.utils.file_utils import (  # pylint: disable=import-outside-toplevel
+        ensure_dir_writable,
+    )
+
+    ensure_dir_writable(output_dir)
+
     # Lazy import watcher to avoid unnecessary deps if not used
     from importlib import import_module  # pylint: disable=import-outside-toplevel
 
@@ -241,7 +248,6 @@ def transcribe(
             help="Directory to save the transcription outputs.",
             file_okay=False,
             dir_okay=True,
-            writable=True,
             resolve_path=True,
         ),
     ] = "./output",
@@ -386,7 +392,6 @@ def transcribe(
             help="Directory for benchmark output JSON files.",
             file_okay=False,
             dir_okay=True,
-            writable=True,
             resolve_path=True,
         ),
     ] = BENCHMARK_OUTPUT_DIR,

--- a/parakeet_rocm/transcription/cli.py
+++ b/parakeet_rocm/transcription/cli.py
@@ -50,6 +50,7 @@ from parakeet_rocm.utils.constant import (
     NEMO_LOG_LEVEL,
     TRANSFORMERS_VERBOSITY,
 )
+from parakeet_rocm.utils.file_utils import ensure_dir_writable
 from parakeet_rocm.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -290,7 +291,7 @@ def cli_transcribe(
         )
         typer.echo()
 
-    output_dir.mkdir(parents=True, exist_ok=True)
+    ensure_dir_writable(output_dir)
 
     # Initialize benchmark collector and GPU sampler if benchmark mode is enabled
     benchmark_collector = collector

--- a/parakeet_rocm/utils/file_utils.py
+++ b/parakeet_rocm/utils/file_utils.py
@@ -4,12 +4,14 @@ All functions are type-hinted and documented. The module exposes:
 • `get_unique_filename` - unchanged
 • `resolve_input_paths` - expand wildcard patterns / directories into concrete
   paths
+• `ensure_dir_writable` - verify a directory is writable via actual write test
 • `AUDIO_EXTENSIONS` - set of allowed audio filename extensions
 """
 
 from __future__ import annotations
 
 import pathlib
+import tempfile
 from collections.abc import Iterable, Sequence
 from glob import glob
 
@@ -44,6 +46,7 @@ AUDIO_EXTENSIONS: set[str] = {
 
 __all__ = [
     "AUDIO_EXTENSIONS",
+    "ensure_dir_writable",
     "get_unique_filename",
     "resolve_input_paths",
 ]
@@ -88,6 +91,48 @@ def get_unique_filename(
         # Safety check to prevent infinite loops
         if counter > 9999:
             raise RuntimeError(f"Cannot find unique filename for {base_path}")
+
+
+def ensure_dir_writable(
+    dir_path: pathlib.Path | str,
+    *,
+    label: str = "Output directory",
+) -> pathlib.Path:
+    """Ensure a directory exists and is writable by performing an actual write test.
+
+    Unlike ``os.access(path, os.W_OK)`` — which can return false negatives on
+    CIFS/SMB mounts configured with ``nounix`` — this function verifies
+    writability by creating and then deleting a small temporary file inside
+    the target directory.
+
+    Args:
+        dir_path: Path to the directory to validate.
+        label: Human-readable label used in error messages.
+
+    Returns:
+        The validated ``pathlib.Path`` object.
+
+    Raises:
+        OSError: If the directory cannot be created or is not writable.
+    """
+    if isinstance(dir_path, str):
+        dir_path = pathlib.Path(dir_path)
+
+    dir_path.mkdir(parents=True, exist_ok=True)
+
+    probe = dir_path / f".write_probe_{tempfile.gettempprefix()}"
+    try:
+        probe.write_text("probe", encoding="utf-8")
+        probe.unlink(missing_ok=True)
+    except OSError as exc:
+        raise OSError(
+            f"{label} '{dir_path}' is not writable: {exc}. "
+            "This can happen on CIFS/SMB mounts with 'nounix' when the mount "
+            "is temporarily unresponsive. Verify the mount is healthy and "
+            "try again."
+        ) from exc
+
+    return dir_path
 
 
 def _is_audio_file(path: pathlib.Path, exts: Sequence[str] | set[str] | None = None) -> bool:  # noqa: D401

--- a/parakeet_rocm/utils/file_utils.py
+++ b/parakeet_rocm/utils/file_utils.py
@@ -120,10 +120,14 @@ def ensure_dir_writable(
 
     dir_path.mkdir(parents=True, exist_ok=True)
 
-    probe = dir_path / f".write_probe_{tempfile.gettempprefix()}"
     try:
-        probe.write_text("probe", encoding="utf-8")
-        probe.unlink(missing_ok=True)
+        with tempfile.NamedTemporaryFile(
+            dir=dir_path,
+            prefix=".write_probe_",
+            delete=True,
+        ) as probe:
+            probe.write(b"probe")
+            probe.flush()
     except OSError as exc:
         raise OSError(
             f"{label} '{dir_path}' is not writable: {exc}. "

--- a/parakeet_rocm/utils/file_utils.py
+++ b/parakeet_rocm/utils/file_utils.py
@@ -118,9 +118,8 @@ def ensure_dir_writable(
     if isinstance(dir_path, str):
         dir_path = pathlib.Path(dir_path)
 
-    dir_path.mkdir(parents=True, exist_ok=True)
-
     try:
+        dir_path.mkdir(parents=True, exist_ok=True)
         with tempfile.NamedTemporaryFile(
             dir=dir_path,
             prefix=".write_probe_",

--- a/parakeet_rocm/utils/file_utils.py
+++ b/parakeet_rocm/utils/file_utils.py
@@ -114,6 +114,7 @@ def ensure_dir_writable(
 
     Raises:
         OSError: If the directory cannot be created or is not writable.
+
     """
     if isinstance(dir_path, str):
         dir_path = pathlib.Path(dir_path)

--- a/tests/integration/test_file_utils.py
+++ b/tests/integration/test_file_utils.py
@@ -1,5 +1,6 @@
 """Tests for file utilities."""
 
+import os
 import pathlib
 import tempfile
 from collections.abc import Generator
@@ -103,6 +104,7 @@ class TestEnsureDirWritable:
         result = ensure_dir_writable(target)
         assert result.is_dir()
 
+    @pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses file permissions")
     def test_readonly_dir_raises_os_error(self, temp_dir: pathlib.Path) -> None:
         """Test that a read-only directory raises OSError with helpful message."""
         readonly_dir = temp_dir / "readonly"
@@ -114,6 +116,7 @@ class TestEnsureDirWritable:
         finally:
             readonly_dir.chmod(0o755)
 
+    @pytest.mark.skipif(os.geteuid() == 0, reason="root bypasses file permissions")
     def test_custom_label_in_error(self, temp_dir: pathlib.Path) -> None:
         """Test that the custom label appears in the error message."""
         readonly_dir = temp_dir / "ro"
@@ -129,6 +132,7 @@ class TestEnsureDirWritable:
         """Test that the write probe file is deleted after validation."""
         ensure_dir_writable(temp_dir)
         probe_files = list(temp_dir.glob(".write_probe_*"))
+        # NamedTemporaryFile(delete=True) handles cleanup automatically
         assert probe_files == []
 
     def test_string_path_input(self, temp_dir: pathlib.Path) -> None:

--- a/tests/integration/test_file_utils.py
+++ b/tests/integration/test_file_utils.py
@@ -6,7 +6,7 @@ from collections.abc import Generator
 
 import pytest
 
-from parakeet_rocm.utils.file_utils import get_unique_filename
+from parakeet_rocm.utils.file_utils import ensure_dir_writable, get_unique_filename
 
 pytestmark = pytest.mark.integration
 
@@ -85,3 +85,53 @@ def test_get_unique_filename_with_extension(temp_dir: pathlib.Path) -> None:
     result = get_unique_filename(test_path, separator="-")
     expected = temp_dir / "document-1.srt"
     assert result == expected
+
+
+class TestEnsureDirWritable:
+    """Tests for ensure_dir_writable."""
+
+    def test_writable_existing_dir(self, temp_dir: pathlib.Path) -> None:
+        """Test that an existing writable directory passes validation."""
+        result = ensure_dir_writable(temp_dir)
+        assert result == temp_dir
+        assert result.is_dir()
+
+    def test_creates_missing_dir(self, temp_dir: pathlib.Path) -> None:
+        """Test that a non-existent directory is created and validated."""
+        target = temp_dir / "nested" / "subdir"
+        assert not target.exists()
+        result = ensure_dir_writable(target)
+        assert result.is_dir()
+
+    def test_readonly_dir_raises_os_error(self, temp_dir: pathlib.Path) -> None:
+        """Test that a read-only directory raises OSError with helpful message."""
+        readonly_dir = temp_dir / "readonly"
+        readonly_dir.mkdir()
+        readonly_dir.chmod(0o444)
+        try:
+            with pytest.raises(OSError, match="not writable"):
+                ensure_dir_writable(readonly_dir)
+        finally:
+            readonly_dir.chmod(0o755)
+
+    def test_custom_label_in_error(self, temp_dir: pathlib.Path) -> None:
+        """Test that the custom label appears in the error message."""
+        readonly_dir = temp_dir / "ro"
+        readonly_dir.mkdir()
+        readonly_dir.chmod(0o444)
+        try:
+            with pytest.raises(OSError, match="Benchmark directory"):
+                ensure_dir_writable(readonly_dir, label="Benchmark directory")
+        finally:
+            readonly_dir.chmod(0o755)
+
+    def test_probe_file_cleaned_up(self, temp_dir: pathlib.Path) -> None:
+        """Test that the write probe file is deleted after validation."""
+        ensure_dir_writable(temp_dir)
+        probe_files = list(temp_dir.glob(".write_probe_*"))
+        assert probe_files == []
+
+    def test_string_path_input(self, temp_dir: pathlib.Path) -> None:
+        """Test that a string path is accepted and converted."""
+        result = ensure_dir_writable(str(temp_dir))
+        assert isinstance(result, pathlib.Path)


### PR DESCRIPTION
# Pull Request: Fix CIFS mount "not writable" false negative

## Summary

Replaces Click's `writable=True` (which uses `os.access()`) with an actual write-probe test (`ensure_dir_writable()`) so that output directories on CIFS/SMB mounts with `nounix` are no longer incorrectly rejected.

## Why

- Click's `writable=True` calls `os.access(path, os.W_OK)`, which returns **false negatives** on CIFS mounts configured with `nounix` — even when the directory is genuinely writable.
- Users running `--watch` against SMB-backed directories (e.g. `/mnt/pm_dest`) hit a hard stop at argument parsing before any transcription starts.
- Python's own docs warn that `os.access()` is unreliable on network filesystems.

## Notable changes (reviewer focus)

- New `ensure_dir_writable()` in `file_utils.py` — creates+deletes a `.write_probe_*` file as a ground-truth writability check; also creates the directory if missing.
- Removed `writable=True` from `--output-dir` and `--benchmark-dir` Click options in `cli.py`.
- `cli_transcribe()` and `_setup_watch_mode()` now call `ensure_dir_writable()` early, before model loading.
- `BenchmarkCollector.__init__` uses `ensure_dir_writable()` instead of bare `mkdir()`.
- Error message includes CIFS-specific guidance when the probe fails.

## Files changed

- **Counts:** 5 files changed (0 added, 5 modified).
- **Key touchpoints:** `utils/file_utils.py` (new function), `cli.py` (Click opts + watch mode), `transcription/cli.py` (output validation), `benchmarks/collector.py` (mkdir→ensure), `tests/integration/test_file_utils.py` (6 new tests).

<details>
<summary>File lists (auto)</summary>

### Added

- _(none)_

### Modified

- `parakeet_rocm/benchmarks/collector.py`
- `parakeet_rocm/cli.py`
- `parakeet_rocm/transcription/cli.py`
- `parakeet_rocm/utils/file_utils.py`
- `tests/integration/test_file_utils.py`

### Deleted

- _(none)_

</details>

## Test plan

- [x] Unit: 285 unit tests pass (no regressions).
- [x] Integration: 6 new `TestEnsureDirWritable` tests (writable dir, auto-create, read-only raises, custom label, probe cleanup, string input) — all pass.
- [x] Manual: `pdm run parakeet-rocm transcribe --output-dir /mnt/pm_dest --watch /mnt/pm_audio --allow-unsafe-filenames` starts successfully; no "not writable" error.

## Risks & rollback

- **Risks:** The write probe creates a tiny temp file (bytes) and deletes it immediately — negligible I/O overhead even on slow mounts. If the mount is genuinely down, the error surfaces earlier (before model load) which is an improvement.
- **Rollback:** Revert this PR; Click's `writable=True` will be restored but the CIFS false-negative will return.

## Additional notes

- The threading `SystemExit` exception on Ctrl+C during watch mode is a pre-existing, unrelated Python 3.10 atexit cleanup race — not introduced by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now validates target directories up front (including watch mode) and surfaces clearer, contextual errors when directories aren’t writable.

* **Refactor**
  * Directory creation and writable-check logic centralized for consistent behavior across commands.

* **Tests**
  * Added integration tests covering writable checks, nested directory creation, probe cleanup, string-path handling, and error-message content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->