### PR TITLE
fix 🐛: Fix unclean Ctrl+C exit in --watch mode

### DIFF
--- a/parakeet_rocm/utils/watch.py
+++ b/parakeet_rocm/utils/watch.py
@@ -169,21 +169,20 @@ def watch_and_transcribe(
     patterns = list(patterns)
     print(f"[watch] Monitoring {', '.join(map(str, patterns))} …  (Press Ctrl+C to stop)")
 
-    _stop_event.clear()
     original_handler: signal.Handlers | int = signal.SIG_DFL
-    if threading.current_thread() is threading.main_thread():
-        try:
-            original_handler = signal.signal(signal.SIGINT, _default_sig_handler)
-        except ValueError:  # pragma: no cover
-            # In rare environments the signal module may still reject handler changes.
-            pass
-
-    seen: set[Path] = set()
-    last_activity = time.monotonic()
-    unloaded = False  # prevent spamming unload calls/logs while idle
-    cleared = False  # whether we already cleared the model cache
-
     try:
+        if threading.current_thread() is threading.main_thread():
+            try:
+                original_handler = signal.signal(signal.SIGINT, _default_sig_handler)
+            except ValueError:  # pragma: no cover
+                # In rare environments the signal module may still reject handler changes.
+                pass
+        _stop_event.clear()
+
+        seen: set[Path] = set()
+        last_activity = time.monotonic()
+        unloaded = False  # prevent spamming unload calls/logs while idle
+        cleared = False  # whether we already cleared the model cache
         while not _stop_event.is_set():
             all_matches = resolve_input_paths(patterns, audio_exts=audio_exts or AUDIO_EXTENSIONS)
             if verbose:

--- a/parakeet_rocm/utils/watch.py
+++ b/parakeet_rocm/utils/watch.py
@@ -58,8 +58,8 @@ def _default_sig_handler(_signum: int, _frame: FrameType | None) -> None:  # noq
         _frame: Current stack frame (unused).
 
     """
-    print("\n[watch] Stopping…")
     _stop_event.set()
+    print("\n[watch] Stopping…")
 
 
 def _needs_transcription(
@@ -171,13 +171,13 @@ def watch_and_transcribe(
 
     original_handler: signal.Handlers | int = signal.SIG_DFL
     try:
+        _stop_event.clear()
         if threading.current_thread() is threading.main_thread():
             try:
                 original_handler = signal.signal(signal.SIGINT, _default_sig_handler)
             except ValueError:  # pragma: no cover
                 # In rare environments the signal module may still reject handler changes.
                 pass
-        _stop_event.clear()
 
         seen: set[Path] = set()
         last_activity = time.monotonic()

--- a/parakeet_rocm/utils/watch.py
+++ b/parakeet_rocm/utils/watch.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import re
 import signal
-import sys
 import threading
 import time
 from collections.abc import Callable, Iterable, Sequence
@@ -40,9 +39,19 @@ from parakeet_rocm.utils.file_utils import (
 
 __all__ = ["watch_and_transcribe"]
 
+# Module-level stop event used by the SIGINT handler to cooperatively
+# break the poll loop in :func:`watch_and_transcribe`.
+_stop_event = threading.Event()
+
 
 def _default_sig_handler(_signum: int, _frame: FrameType | None) -> None:  # noqa: D401
     """Handle ``SIGINT`` (Ctrl-C) gracefully.
+
+    Sets the module-level stop event so the poll loop in
+    :func:`watch_and_transcribe` exits cooperatively.  This avoids
+    calling ``sys.exit`` from inside a signal handler, which can
+    cause nested ``SystemExit`` during atexit cleanup (e.g. torch
+    ``dump_compile_times``).
 
     Args:
         _signum: Received POSIX signal number (unused).
@@ -50,7 +59,7 @@ def _default_sig_handler(_signum: int, _frame: FrameType | None) -> None:  # noq
 
     """
     print("\n[watch] Stopping…")
-    sys.exit(0)
+    _stop_event.set()
 
 
 def _needs_transcription(
@@ -160,9 +169,11 @@ def watch_and_transcribe(
     patterns = list(patterns)
     print(f"[watch] Monitoring {', '.join(map(str, patterns))} …  (Press Ctrl+C to stop)")
 
+    _stop_event.clear()
+    original_handler: signal.Handlers | int = signal.SIG_DFL
     if threading.current_thread() is threading.main_thread():
         try:
-            signal.signal(signal.SIGINT, _default_sig_handler)
+            original_handler = signal.signal(signal.SIGINT, _default_sig_handler)
         except ValueError:  # pragma: no cover
             # In rare environments the signal module may still reject handler changes.
             pass
@@ -172,64 +183,75 @@ def watch_and_transcribe(
     unloaded = False  # prevent spamming unload calls/logs while idle
     cleared = False  # whether we already cleared the model cache
 
-    while True:
-        all_matches = resolve_input_paths(patterns, audio_exts=audio_exts or AUDIO_EXTENSIONS)
-        if verbose:
-            print(f"[watch] Scan found {len(all_matches)} candidate file(s)")
-        new_paths: list[Path] = []
-        for p in all_matches:
-            if p in seen:
+    try:
+        while not _stop_event.is_set():
+            all_matches = resolve_input_paths(patterns, audio_exts=audio_exts or AUDIO_EXTENSIONS)
+            if verbose:
+                print(f"[watch] Scan found {len(all_matches)} candidate file(s)")
+            new_paths: list[Path] = []
+            for p in all_matches:
+                if p in seen:
+                    if verbose:
+                        print(f"[watch] ✗ Already processed: {p}")
+                    continue
+                if _needs_transcription(
+                    p,
+                    output_dir,
+                    output_template,
+                    output_format,
+                    watch_base_dirs=watch_base_dirs,
+                ):
+                    new_paths.append(p)
+                    seen.add(p)
+                else:
+                    if verbose:
+                        print(f"[watch] ✗ Output exists, skipping: {p}")
+            if new_paths:
                 if verbose:
-                    print(f"[watch] ✗ Already processed: {p}")
-                continue
-            if _needs_transcription(
-                p,
-                output_dir,
-                output_template,
-                output_format,
-                watch_base_dirs=watch_base_dirs,
-            ):
-                new_paths.append(p)
-                seen.add(p)
+                    print(f"[watch] Found {len(new_paths)} new file(s):")
+                    for file in new_paths:
+                        print(f"- {file}")
+                transcribe_fn(new_paths)
+                # Mark activity and reset idle state
+                last_activity = time.monotonic()
+                if unloaded or cleared:
+                    # A new job arrived after idle; the model will be promoted back
+                    # to GPU automatically on next get_model(). Reset flag.
+                    unloaded = False
+                    cleared = False
             else:
                 if verbose:
-                    print(f"[watch] ✗ Output exists, skipping: {p}")
-        if new_paths:
-            if verbose:
-                print(f"[watch] Found {len(new_paths)} new file(s):")
-                for file in new_paths:
-                    print(f"- {file}")
-            transcribe_fn(new_paths)
-            # Mark activity and reset idle state
-            last_activity = time.monotonic()
-            if unloaded or cleared:
-                # A new job arrived after idle; the model will be promoted back
-                # to GPU automatically on next get_model(). Reset flag.
-                unloaded = False
-                cleared = False
-        else:
-            if verbose:
-                print("[watch] No new files - waiting…")
-            # Idle handling: offload model to CPU if idle timeout exceeded
-            now = time.monotonic()
-            if not unloaded and (now - last_activity) >= IDLE_UNLOAD_TIMEOUT_SEC:
-                try:
-                    if verbose:
-                        print(
-                            f"[watch] Idle for >= {IDLE_UNLOAD_TIMEOUT_SEC}s - "
-                            "offloading model to CPU"
-                        )
-                    unload_model_to_cpu()
-                finally:
-                    unloaded = True
-            # If still idle past clear timeout, drop the cache entirely
-            if not cleared and (now - last_activity) >= IDLE_CLEAR_TIMEOUT_SEC:
-                try:
-                    if verbose:
-                        print(
-                            f"[watch] Idle for >= {IDLE_CLEAR_TIMEOUT_SEC}s - clearing model cache"
-                        )
-                    clear_model_cache()
-                finally:
-                    cleared = True
-        time.sleep(poll_interval)
+                    print("[watch] No new files - waiting…")
+                # Idle handling: offload model to CPU if idle timeout exceeded
+                now = time.monotonic()
+                if not unloaded and (now - last_activity) >= IDLE_UNLOAD_TIMEOUT_SEC:
+                    try:
+                        if verbose:
+                            print(
+                                f"[watch] Idle for >= {IDLE_UNLOAD_TIMEOUT_SEC}s - "
+                                "offloading model to CPU"
+                            )
+                        unload_model_to_cpu()
+                    finally:
+                        unloaded = True
+                # If still idle past clear timeout, drop the cache entirely
+                if not cleared and (now - last_activity) >= IDLE_CLEAR_TIMEOUT_SEC:
+                    try:
+                        if verbose:
+                            print(
+                                f"[watch] Idle for >= {IDLE_CLEAR_TIMEOUT_SEC}s - "
+                                "clearing model cache"
+                            )
+                        clear_model_cache()
+                    finally:
+                        cleared = True
+            time.sleep(poll_interval)
+    finally:
+        # Restore the previous SIGINT handler so the caller's signal
+        # handling is not permanently altered.
+        if threading.current_thread() is threading.main_thread():
+            try:
+                signal.signal(signal.SIGINT, original_handler)
+            except ValueError:  # pragma: no cover
+                pass
+        _stop_event.clear()

--- a/tests/integration/test_watch_and_file_utils.py
+++ b/tests/integration/test_watch_and_file_utils.py
@@ -111,7 +111,7 @@ def test_watch_and_transcribe(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib
     assert audio_file in called
 
 
-def test_default_sig_handler_sets_stop_event() -> None:
+def test_default_sig_handler__sets_stop_event() -> None:
     """Ensure the default signal handler sets the cooperative stop event."""
     _stop_event.clear()
     try:

--- a/tests/integration/test_watch_and_file_utils.py
+++ b/tests/integration/test_watch_and_file_utils.py
@@ -114,9 +114,11 @@ def test_watch_and_transcribe(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib
 def test_default_sig_handler_sets_stop_event() -> None:
     """Ensure the default signal handler sets the cooperative stop event."""
     _stop_event.clear()
-    _default_sig_handler(2, None)
-    assert _stop_event.is_set()
-    _stop_event.clear()
+    try:
+        _default_sig_handler(2, None)
+        assert _stop_event.is_set()
+    finally:
+        _stop_event.clear()
 
 
 def test_needs_transcription(tmp_path: pathlib.Path) -> None:

--- a/tests/integration/test_watch_and_file_utils.py
+++ b/tests/integration/test_watch_and_file_utils.py
@@ -13,6 +13,7 @@ from parakeet_rocm.utils.file_utils import (
 from parakeet_rocm.utils.watch import (
     _default_sig_handler,
     _needs_transcription,
+    _stop_event,
     watch_and_transcribe,
 )
 
@@ -110,10 +111,12 @@ def test_watch_and_transcribe(monkeypatch: pytest.MonkeyPatch, tmp_path: pathlib
     assert audio_file in called
 
 
-def test_default_sig_handler_exits() -> None:
-    """Ensure the default signal handler raises `SystemExit`."""
-    with pytest.raises(SystemExit):
-        _default_sig_handler(2, None)
+def test_default_sig_handler_sets_stop_event() -> None:
+    """Ensure the default signal handler sets the cooperative stop event."""
+    _stop_event.clear()
+    _default_sig_handler(2, None)
+    assert _stop_event.is_set()
+    _stop_event.clear()
 
 
 def test_needs_transcription(tmp_path: pathlib.Path) -> None:

--- a/tests/unit/test_utils_watch.py
+++ b/tests/unit/test_utils_watch.py
@@ -365,3 +365,55 @@ def test_watch_and_transcribe_activity_resets_idle_state(
     # Should have called unload once, but new activity should have reset state
     assert mock_unload.call_count == 1
     assert transcribe_mock.call_count == 1
+
+
+@patch("parakeet_rocm.utils.watch.resolve_input_paths")
+def test_watch_cooperative_sigint_shutdown(
+    mock_resolve: MagicMock,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """SIGINT sets the stop event; watch_and_transcribe exits cleanly without sys.exit."""
+    import signal
+
+    from parakeet_rocm.utils.watch import _default_sig_handler, _stop_event
+
+    # Ensure the stop event is clear before the test
+    _stop_event.clear()
+
+    # Mock no files found so the loop stays idle
+    mock_resolve.return_value = []
+
+    transcribe_mock = MagicMock()
+
+    # Simulate SIGINT after one sleep cycle
+    call_count = 0
+
+    def mock_sleep(*_args: object) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 1:
+            # Simulate what the signal handler does
+            _default_sig_handler(signal.SIGINT, None)
+
+    original_sig = signal.getsignal(signal.SIGINT)
+    with patch("time.sleep", side_effect=mock_sleep):
+        watch_and_transcribe(
+            patterns=[tmp_path],
+            transcribe_fn=transcribe_mock,
+            poll_interval=0.1,
+            output_dir=tmp_path,
+            output_format="txt",
+            output_template="{filename}",
+            verbose=False,
+        )
+
+    # Function should have returned normally (no SystemExit / KeyboardInterrupt)
+    captured = capsys.readouterr()
+    assert "[watch] Stopping…" in captured.out
+
+    # The original SIGINT handler must be restored
+    assert signal.getsignal(signal.SIGINT) is original_sig
+
+    # The stop event must be cleared after exit (ready for reuse)
+    assert not _stop_event.is_set()


### PR DESCRIPTION
# Pull Request: Fix unclean Ctrl+C exit in --watch mode

## Summary

Replaces `sys.exit(0)` in the watch-mode SIGINT handler with a cooperative `threading.Event` shutdown, eliminating the ugly atexit traceback and duplicate stop message when pressing Ctrl+C.

## Why

- Pressing Ctrl+C in `--watch` mode called `sys.exit(0)` from the signal handler, which triggered torch's `dump_compile_times` atexit callback and produced a nested `SystemExit` traceback.
- The signal handler fired twice during shutdown, printing `[watch] Stopping…` twice.
- A signal handler should never call `sys.exit`; it should cooperatively signal the main loop to exit.

## Notable changes (reviewer focus)

- `_default_sig_handler` now sets `_stop_event` (a `threading.Event`) instead of calling `sys.exit(0)`.
- `watch_and_transcribe` loop changed from `while True` to `while not _stop_event.is_set()`, wrapped in `try/finally`.
- Original SIGINT handler is saved on entry and restored in the `finally` block.
- `_stop_event.clear()` is called on entry and exit for reuse safety.

## Files changed

- **Counts:** 4 files changed (0 added, 4 modified, 0 deleted).
- **Key touchpoints:** watch signal handling, watch poll loop, unit & integration tests for watch shutdown.

<details>
<summary>File lists (auto)</summary>

### Added
- *(none)*

### Modified
- `parakeet_rocm/chunking/merge.py` — docstring sync (merge artifact, no logic change)
- `parakeet_rocm/utils/watch.py`
- `tests/integration/test_watch_and_file_utils.py`
- `tests/unit/test_utils_watch.py`

### Deleted
- *(none)*

</details>

## Test plan

- [x] Unit: `test_watch_cooperative_sigint_shutdown` — verifies clean return, handler restoration, stop event cleanup.
- [x] Integration: `test_default_sig_handler_sets_stop_event` — replaces old `SystemExit` test.
- [x] All 357 existing tests pass (`scripts/local-ci.sh`).

## Risks & rollback

- **Risks:** If a caller depends on `SystemExit` being raised from the signal handler (unlikely — no such usage found), behavior changes to a normal return.
- **Rollback:** Revert this PR; `sys.exit(0)` behavior is restored.

## Additional notes

- Closes #36.
- The `merge.py` docstring diff is a merge artifact from #10 — no logic change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ctrl+C behavior in watch mode: interrupt now triggers a graceful, cooperative shutdown with proper cleanup and a clear "Stopping…" message, avoiding abrupt process termination and preserving normal signal handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->