### PR TITLE
fix 🐛: Fail-fast filename validation + watch SIGINT hardening

### DIFF
--- a/parakeet_rocm/transcription/cli.py
+++ b/parakeet_rocm/transcription/cli.py
@@ -32,7 +32,10 @@ from parakeet_rocm.config import (
     UIConfig,
 )
 from parakeet_rocm.formatting import get_formatter
-from parakeet_rocm.transcription.file_processor import transcribe_file
+from parakeet_rocm.transcription.file_processor import (
+    transcribe_file,
+    validate_output_filenames,
+)
 from parakeet_rocm.transcription.utils import (
     compute_total_segments,
     configure_environment,
@@ -292,6 +295,23 @@ def cli_transcribe(
         typer.echo()
 
     ensure_dir_writable(output_dir)
+
+    # Pre-flight filename validation — fail before expensive model loading
+    validation_errors = validate_output_filenames(
+        audio_files,
+        output_template,
+        allow_unsafe=allow_unsafe_filenames,
+    )
+    if validation_errors:
+        for path, msg in validation_errors:
+            typer.echo(f"Error: {path}: {msg}", err=True)
+        if not allow_unsafe_filenames:
+            typer.echo(
+                "Hint: use --allow-unsafe-filenames to allow spaces and "
+                "special characters in filenames.",
+                err=True,
+            )
+        raise typer.Exit(code=1)
 
     # Initialize benchmark collector and GPU sampler if benchmark mode is enabled
     benchmark_collector = collector

--- a/parakeet_rocm/transcription/file_processor.py
+++ b/parakeet_rocm/transcription/file_processor.py
@@ -118,7 +118,7 @@ def validate_output_filenames(
     - The rendered template result using ``{filename}``, ``{index}``,
       ``{parent}``, and ``{date}`` placeholders
 
-    Parameters:
+    Args:
         audio_files: Audio file paths whose output names should be validated.
         output_template: Filename template supporting ``{filename}``,
             ``{index}``, ``{parent}``, and ``{date}`` placeholders.
@@ -167,7 +167,7 @@ def validate_output_filenames(
         }
         try:
             filename_part = output_template.format(**template_context)
-        except Exception as exc:
+        except (AttributeError, IndexError, KeyError, TypeError, ValueError) as exc:
             errors.append((audio_path, f"Invalid --output-template: {exc}"))
             continue
 

--- a/parakeet_rocm/transcription/file_processor.py
+++ b/parakeet_rocm/transcription/file_processor.py
@@ -98,6 +98,91 @@ def _validate_filename_component(
     return value
 
 
+def validate_output_filenames(
+    audio_files: Sequence[Path],
+    output_template: str,
+    *,
+    allow_unsafe: bool = False,
+) -> list[tuple[Path, str]]:
+    """Pre-flight validation of all output filename components for a batch.
+
+    Validates every filename-derived value that will be used during output
+    rendering, so that invalid configurations are caught **before** expensive
+    model inference begins.
+
+    For each audio file the following components are checked via
+    ``_validate_filename_component``:
+
+    - ``audio_path.stem`` (input filename without extension)
+    - ``audio_path.parent.name`` (parent directory name)
+    - The rendered template result using ``{filename}``, ``{index}``,
+      ``{parent}``, and ``{date}`` placeholders
+
+    Parameters:
+        audio_files: Audio file paths whose output names should be validated.
+        output_template: Filename template supporting ``{filename}``,
+            ``{index}``, ``{parent}``, and ``{date}`` placeholders.
+        allow_unsafe: When ``True``, use relaxed filename validation that
+            permits spaces, brackets, quotes, and other non-ASCII characters
+            while still enforcing security invariants.
+
+    Returns:
+        A list of ``(path, error_message)`` tuples.  The list is empty when
+        all filenames pass validation.
+    """
+    errors: list[tuple[Path, str]] = []
+    date_str = datetime.now().strftime("%Y%m%d")
+
+    for file_idx, audio_path in enumerate(audio_files, start=1):
+        parent_name = audio_path.parent.name or "root"
+
+        # Validate input filename stem
+        try:
+            _validate_filename_component(
+                audio_path.stem,
+                label="Input filename",
+                allow_unsafe=allow_unsafe,
+            )
+        except ValueError as exc:
+            errors.append((audio_path, str(exc)))
+            continue
+
+        # Validate parent directory name
+        try:
+            _validate_filename_component(
+                parent_name,
+                label="Input parent directory",
+                allow_unsafe=allow_unsafe,
+            )
+        except ValueError as exc:
+            errors.append((audio_path, str(exc)))
+            continue
+
+        # Validate rendered template result
+        template_context = {
+            "filename": audio_path.stem,
+            "index": file_idx,
+            "parent": parent_name,
+            "date": date_str,
+        }
+        try:
+            filename_part = output_template.format(**template_context)
+        except KeyError as exc:
+            errors.append((audio_path, f"Unknown placeholder in --output-template: {exc}"))
+            continue
+
+        try:
+            _validate_filename_component(
+                filename_part,
+                label="Output template result",
+                allow_unsafe=allow_unsafe,
+            )
+        except ValueError as exc:
+            errors.append((audio_path, str(exc)))
+
+    return errors
+
+
 def _dedupe_nearby_repeats(
     tokens: list[str],
     *,

--- a/parakeet_rocm/transcription/file_processor.py
+++ b/parakeet_rocm/transcription/file_processor.py
@@ -167,8 +167,8 @@ def validate_output_filenames(
         }
         try:
             filename_part = output_template.format(**template_context)
-        except KeyError as exc:
-            errors.append((audio_path, f"Unknown placeholder in --output-template: {exc}"))
+        except Exception as exc:
+            errors.append((audio_path, f"Invalid --output-template: {exc}"))
             continue
 
         try:

--- a/parakeet_rocm/utils/watch.py
+++ b/parakeet_rocm/utils/watch.py
@@ -60,6 +60,8 @@ def _default_sig_handler(_signum: int, _frame: FrameType | None) -> None:  # noq
         _frame: Current stack frame (unused).
 
     """
+    if _stop_event.is_set():
+        return
     _stop_event.set()
     try:
         os.write(sys.stdout.fileno(), "\n[watch] Stopping…\n".encode())

--- a/parakeet_rocm/utils/watch.py
+++ b/parakeet_rocm/utils/watch.py
@@ -16,8 +16,10 @@ assumes a transcription already exists.
 
 from __future__ import annotations
 
+import os
 import re
 import signal
+import sys
 import threading
 import time
 from collections.abc import Callable, Iterable, Sequence
@@ -59,7 +61,11 @@ def _default_sig_handler(_signum: int, _frame: FrameType | None) -> None:  # noq
 
     """
     _stop_event.set()
-    print("\n[watch] Stopping…")
+    try:
+        os.write(sys.stdout.fileno(), "\n[watch] Stopping…\n".encode())
+    except (OSError, AttributeError):
+        sys.stdout.write("\n[watch] Stopping…\n")
+        sys.stdout.flush()
 
 
 def _needs_transcription(

--- a/tests/unit/test_filename_validation.py
+++ b/tests/unit/test_filename_validation.py
@@ -1,14 +1,19 @@
-"""Tests for filename validation in ``_validate_filename_component``.
+"""Tests for filename validation helpers and batch pre-flight checks.
 
 Covers strict mode, relaxed (``allow_unsafe``) mode, and security invariants
-that must hold in **both** modes.
+that must hold in **both** modes, plus batch pre-flight validation.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
-from parakeet_rocm.transcription.file_processor import _validate_filename_component
+from parakeet_rocm.transcription.file_processor import (
+    _validate_filename_component,
+    validate_output_filenames,
+)
 
 
 # -----------------------------------------------------------------------
@@ -179,3 +184,66 @@ class TestSecurityInvariants:
                 label="test",
                 allow_unsafe=True,
             )
+
+
+# -----------------------------------------------------------------------
+# Batch pre-flight validation — validate_output_filenames
+# -----------------------------------------------------------------------
+class TestValidateOutputFilenames:
+    """Batch pre-flight validation of output filenames."""
+
+    def test_valid_batch_returns_empty(self, tmp_path: Path) -> None:
+        """A valid batch with simple filenames passes without errors."""
+        audio_a = tmp_path / "a.wav"
+        audio_b = tmp_path / "b.wav"
+        errors = validate_output_filenames([audio_a, audio_b], "{filename}")
+        assert errors == []
+
+    def test_single_invalid_filename_reported(self, tmp_path: Path) -> None:
+        """A batch with one invalid filename reports an error for that file."""
+        good = tmp_path / "good.wav"
+        bad = tmp_path / "bad file.wav"
+        errors = validate_output_filenames([good, bad], "{filename}")
+        assert len(errors) == 1
+        assert bad in errors[0]
+
+    def test_multiple_invalid_filenames_all_reported(self, tmp_path: Path) -> None:
+        """Multiple invalid filenames are all reported, not just the first."""
+        bad1 = tmp_path / "bad one.wav"
+        bad2 = tmp_path / "bad two.wav"
+        errors = validate_output_filenames([bad1, bad2], "{filename}")
+        assert len(errors) == 2
+
+    def test_strict_rejects_special_chars(self, tmp_path: Path) -> None:
+        """Strict mode rejects special characters in filenames."""
+        bad = tmp_path / "file[1].wav"
+        errors = validate_output_filenames([bad], "{filename}", allow_unsafe=False)
+        assert len(errors) == 1
+
+    def test_relaxed_accepts_special_chars(self, tmp_path: Path) -> None:
+        """Relaxed mode accepts special characters in filenames."""
+        audio = tmp_path / "file[1].wav"
+        errors = validate_output_filenames([audio], "{filename}", allow_unsafe=True)
+        assert errors == []
+
+    def test_unknown_template_placeholder_reported(self, tmp_path: Path) -> None:
+        """Unknown placeholders in the output template are caught."""
+        audio = tmp_path / "good.wav"
+        errors = validate_output_filenames([audio], "{unknown}")
+        assert len(errors) == 1
+        assert "Unknown placeholder" in errors[0][1]
+
+    def test_invalid_parent_directory_reported(self, tmp_path: Path) -> None:
+        """Invalid parent directory name is reported."""
+        bad_dir = tmp_path / "bad dir"
+        bad_dir.mkdir()
+        audio = bad_dir / "good.wav"
+        errors = validate_output_filenames([audio], "{parent}")
+        assert len(errors) == 1
+
+    def test_invalid_template_result_reported(self, tmp_path: Path) -> None:
+        """Rendered template result that fails validation is reported."""
+        audio = tmp_path / "good.wav"
+        # Template produces a slash which is always forbidden
+        errors = validate_output_filenames([audio], "{filename}/{index}")
+        assert len(errors) == 1

--- a/tests/unit/test_filename_validation.py
+++ b/tests/unit/test_filename_validation.py
@@ -192,14 +192,16 @@ class TestSecurityInvariants:
 class TestValidateOutputFilenames:
     """Batch pre-flight validation of output filenames."""
 
-    def test_valid_batch_returns_empty(self, tmp_path: Path) -> None:
+    def test_validate_output_filenames__valid_batch_returns_empty(self, tmp_path: Path) -> None:
         """A valid batch with simple filenames passes without errors."""
         audio_a = tmp_path / "a.wav"
         audio_b = tmp_path / "b.wav"
         errors = validate_output_filenames([audio_a, audio_b], "{filename}")
         assert errors == []
 
-    def test_single_invalid_filename_reported(self, tmp_path: Path) -> None:
+    def test_validate_output_filenames__single_invalid_filename_reported(
+        self, tmp_path: Path
+    ) -> None:
         """A batch with one invalid filename reports an error for that file."""
         good = tmp_path / "good.wav"
         bad = tmp_path / "bad file.wav"
@@ -207,33 +209,39 @@ class TestValidateOutputFilenames:
         assert len(errors) == 1
         assert bad in errors[0]
 
-    def test_multiple_invalid_filenames_all_reported(self, tmp_path: Path) -> None:
+    def test_validate_output_filenames__multiple_invalid_filenames_all_reported(
+        self, tmp_path: Path
+    ) -> None:
         """Multiple invalid filenames are all reported, not just the first."""
         bad1 = tmp_path / "bad one.wav"
         bad2 = tmp_path / "bad two.wav"
         errors = validate_output_filenames([bad1, bad2], "{filename}")
         assert len(errors) == 2
 
-    def test_strict_rejects_special_chars(self, tmp_path: Path) -> None:
+    def test_validate_output_filenames__strict_rejects_special_chars(self, tmp_path: Path) -> None:
         """Strict mode rejects special characters in filenames."""
         bad = tmp_path / "file[1].wav"
         errors = validate_output_filenames([bad], "{filename}", allow_unsafe=False)
         assert len(errors) == 1
 
-    def test_relaxed_accepts_special_chars(self, tmp_path: Path) -> None:
+    def test_validate_output_filenames__relaxed_accepts_special_chars(self, tmp_path: Path) -> None:
         """Relaxed mode accepts special characters in filenames."""
         audio = tmp_path / "file[1].wav"
         errors = validate_output_filenames([audio], "{filename}", allow_unsafe=True)
         assert errors == []
 
-    def test_unknown_template_placeholder_reported(self, tmp_path: Path) -> None:
+    def test_validate_output_filenames__unknown_template_placeholder_reported(
+        self, tmp_path: Path
+    ) -> None:
         """Unknown placeholders in the output template are caught."""
         audio = tmp_path / "good.wav"
         errors = validate_output_filenames([audio], "{unknown}")
         assert len(errors) == 1
-        assert "Unknown placeholder" in errors[0][1]
+        assert "Invalid --output-template" in errors[0][1]
 
-    def test_invalid_parent_directory_reported(self, tmp_path: Path) -> None:
+    def test_validate_output_filenames__invalid_parent_directory_reported(
+        self, tmp_path: Path
+    ) -> None:
         """Invalid parent directory name is reported."""
         bad_dir = tmp_path / "bad dir"
         bad_dir.mkdir()
@@ -241,7 +249,9 @@ class TestValidateOutputFilenames:
         errors = validate_output_filenames([audio], "{parent}")
         assert len(errors) == 1
 
-    def test_invalid_template_result_reported(self, tmp_path: Path) -> None:
+    def test_validate_output_filenames__invalid_template_result_reported(
+        self, tmp_path: Path
+    ) -> None:
         """Rendered template result that fails validation is reported."""
         audio = tmp_path / "good.wav"
         # Template produces a slash which is always forbidden

--- a/tests/unit/test_transcription_cli.py
+++ b/tests/unit/test_transcription_cli.py
@@ -204,7 +204,7 @@ def test_transcribe_module_exports_cli_transcribe() -> None:
 class TestFilenameValidationFailFast:
     """Ensure invalid filenames cause early exit without loading the model."""
 
-    def test_invalid_filename_exits_before_model_load(
+    def test_cli_transcribe__invalid_filename_exits_before_model_load(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """Invalid input filename in strict mode causes exit before model load."""
@@ -232,7 +232,7 @@ class TestFilenameValidationFailFast:
 
         assert not model_loaded["called"], "get_model was called despite invalid filename"
 
-    def test_invalid_template_placeholder_exits_before_model_load(
+    def test_cli_transcribe__invalid_template_placeholder_exits_before_model_load(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """Invalid output template placeholder causes exit before model load."""
@@ -262,7 +262,7 @@ class TestFilenameValidationFailFast:
 
         assert not model_loaded["called"], "get_model was called despite invalid template"
 
-    def test_valid_filenames_proceed_to_model_load(
+    def test_cli_transcribe__valid_filenames_proceed_to_model_load(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """Valid filenames allow execution to proceed to model loading."""

--- a/tests/unit/test_transcription_cli.py
+++ b/tests/unit/test_transcription_cli.py
@@ -196,3 +196,100 @@ def test_transcribe_module_exports_cli_transcribe() -> None:
     from parakeet_rocm import transcribe
 
     assert transcribe.cli_transcribe is transcription_cli.cli_transcribe
+
+
+# -----------------------------------------------------------------------
+# Fail-fast: filename validation exits before model loading
+# -----------------------------------------------------------------------
+class TestFilenameValidationFailFast:
+    """Ensure invalid filenames cause early exit without loading the model."""
+
+    def test_invalid_filename_exits_before_model_load(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Invalid input filename in strict mode causes exit before model load."""
+        bad = tmp_path / "bad file.wav"
+
+        model_loaded = {"called": False}
+
+        def _assert_never_called(_name: str) -> None:
+            model_loaded["called"] = True
+            raise AssertionError("get_model should not be called on invalid filenames")
+
+        monkeypatch.setattr(transcription_cli, "configure_environment", lambda _v: None)
+        fake_model_module = types.ModuleType("parakeet_rocm.models.parakeet")
+        fake_model_module.get_model = _assert_never_called
+        monkeypatch.setitem(sys.modules, "parakeet_rocm.models.parakeet", fake_model_module)
+
+        with pytest.raises(typer.Exit):
+            transcription_cli.cli_transcribe(
+                audio_files=[bad],
+                output_dir=tmp_path,
+                output_format="txt",
+                quiet=True,
+                no_progress=True,
+            )
+
+        assert not model_loaded["called"], "get_model was called despite invalid filename"
+
+    def test_invalid_template_placeholder_exits_before_model_load(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Invalid output template placeholder causes exit before model load."""
+        audio = tmp_path / "good.wav"
+        audio.write_text("x")
+
+        model_loaded = {"called": False}
+
+        def _assert_never_called(_name: str) -> None:
+            model_loaded["called"] = True
+            raise AssertionError("get_model should not be called on invalid template")
+
+        monkeypatch.setattr(transcription_cli, "configure_environment", lambda _v: None)
+        fake_model_module = types.ModuleType("parakeet_rocm.models.parakeet")
+        fake_model_module.get_model = _assert_never_called
+        monkeypatch.setitem(sys.modules, "parakeet_rocm.models.parakeet", fake_model_module)
+
+        with pytest.raises(typer.Exit):
+            transcription_cli.cli_transcribe(
+                audio_files=[audio],
+                output_dir=tmp_path,
+                output_format="txt",
+                output_template="{unknown}",
+                quiet=True,
+                no_progress=True,
+            )
+
+        assert not model_loaded["called"], "get_model was called despite invalid template"
+
+    def test_valid_filenames_proceed_to_model_load(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Valid filenames allow execution to proceed to model loading."""
+        audio = tmp_path / "good.wav"
+        audio.write_text("x")
+
+        model_loaded = {"called": False}
+
+        def _record_model_load(_name: str) -> _DummyModel:
+            model_loaded["called"] = True
+            return _DummyModel()
+
+        monkeypatch.setattr(transcription_cli, "configure_environment", lambda _v: None)
+        monkeypatch.setattr(transcription_cli, "compute_total_segments", lambda *_: 0)
+        monkeypatch.setattr(transcription_cli, "get_formatter", lambda _fmt: object())
+        monkeypatch.setattr(transcription_cli, "transcribe_file", lambda *a, **kw: None)
+
+        fake_model_module = types.ModuleType("parakeet_rocm.models.parakeet")
+        fake_model_module.get_model = _record_model_load
+        monkeypatch.setitem(sys.modules, "parakeet_rocm.models.parakeet", fake_model_module)
+
+        transcription_cli.cli_transcribe(
+            audio_files=[audio],
+            output_dir=tmp_path,
+            output_format="txt",
+            quiet=True,
+            no_progress=True,
+        )
+
+        assert model_loaded["called"], "get_model was not called for valid filenames"


### PR DESCRIPTION
## Summary

Merges `dev` into `main` with two bug-fix themes:

### 1. Pre-flight filename validation (#32)
- Add `validate_output_filenames()` batch pre-flight check in `file_processor.py`
- Call it in `cli_transcribe()` **before** model loading — invalid filenames/templates fail fast without consuming GPU time
- Unit tests for batch validator and CLI fail-fast behavior

### 2. Watch SIGINT hardening (previous commits)
- Replace `sys.exit(0)` with cooperative shutdown
- Close SIGINT race window and test state leak
- Address CodeRabbit PR #37 review feedback

## Closes
- Closes #32

## Test plan
- [x] `pdm run pytest tests/unit/` — all pass
- [x] `pdm run ruff check .` — clean
- [x] New tests confirm model is never loaded on invalid filenames
- [x] New tests confirm valid filenames proceed to model load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-flight validation of output filenames runs before transcription, reporting per-file errors and aborting early to avoid wasted work; hint shown when unsafe filenames are permitted.

* **Bug Fixes**
  * Improved shutdown handling to avoid redundant state changes and make the final shutdown message more reliable across environments.

* **Tests**
  * Added unit tests covering batch filename validation, template and parent-directory errors, strict vs relaxed modes, and CLI fail-fast behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->