### PR TITLE
feat: evaluate nvidia/parakeet-unified-en-0.6b ASR model (#41)

### DIFF
--- a/docs/evaluation_results/model-comparison-template.md
+++ b/docs/evaluation_results/model-comparison-template.md
@@ -1,0 +1,51 @@
+# Model comparison result template
+
+Copy this template, rename it with the date and hardware, and fill in the
+measurements from a real run of `scripts/evaluate_model.py`.
+
+## Metadata
+
+- Date: YYYY-MM-DD
+- Hardware: e.g. AMD Radeon RX 7900 XTX / ROCm 7.0
+- Baseline model: nvidia/parakeet-tdt-0.6b-v3
+- Candidate model: nvidia/parakeet-unified-en-0.6b
+- Audio source: e.g. data/samples/sample_mono.wav
+- Evaluation script: `pdm run python -m scripts.evaluate_model run ...`
+- Command flags used: (chunk length, batch size, word timestamps on/off, etc.)
+
+## Observations
+
+### Baseline (nvidia/parakeet-tdt-0.6b-v3)
+
+- Runtime: ___ seconds
+- Load time: ___ seconds
+- Word count: ___
+- Segment count: ___
+- Timestamp compatible: yes/no
+- Transcription excerpt: "..."
+
+### Candidate (nvidia/parakeet-unified-en-0.6b)
+
+- Runtime: ___ seconds
+- Load time: ___ seconds
+- Word count: ___
+- Segment count: ___
+- Timestamp compatible: yes/no
+- Transcription excerpt: "..."
+
+### Comparison
+
+- Text similarity ratio: ___
+- Notable transcription differences: ___
+- Timestamp compatibility notes: ___
+- Output format compatibility: txt/json/jsonl/csv/tsv/srt/vtt all rendered?
+
+## Conclusion
+
+Should the candidate model become the new default? What further evidence is
+needed?
+
+## Attachments
+
+- JSON report path/name
+- Markdown report path/name

--- a/docs/model_evaluation.md
+++ b/docs/model_evaluation.md
@@ -1,0 +1,112 @@
+# Model evaluation
+
+This document describes how to compare the default Parakeet ASR model with
+`nvidia/parakeet-unified-en-0.6b` (or any other NeMo ASR model) using the
+evaluation tooling added for Issue #41.
+
+## Quick start
+
+Evaluate the unified model against the default model on a single audio file:
+
+```bash
+pdm run python -m scripts.evaluate_model run data/samples/sample_mono.wav
+```
+
+The script writes machine-readable JSON and human-readable Markdown reports to
+`data/evaluation_results/` by default.
+
+## What is compared
+
+The evaluation script exercises the same transcription pipeline the CLI uses:
+
+- model loading via `parakeet_rocm.models.parakeet.get_model`
+- audio loading and chunked segmentation
+- inference with `return_hypotheses=True`
+- word-timestamp adaptation via `parakeet_rocm.timestamps.adapt`
+- all built-in output formatters: `txt`, `json`, `jsonl`, `csv`, `tsv`, `srt`, `vtt`
+- benchmark metrics via `parakeet_rocm.benchmarks.BenchmarkCollector`
+
+For each audio file the script reports:
+
+- transcription text from both models
+- runtime and model-load time
+- word and segment counts
+- timestamp compatibility flag and notes
+- text similarity ratio between the two transcriptions
+- paths to generated per-format output files
+
+## Commands
+
+### Single file
+
+```bash
+pdm run python -m scripts.evaluate_model run data/samples/sample_mono.wav \
+  --candidate nvidia/parakeet-unified-en-0.6b \
+  --output-dir data/evaluation_results
+```
+
+### Directory of audio files
+
+```bash
+pdm run python -m scripts.evaluate_model run data/samples/ \
+  --output-dir data/evaluation_results
+```
+
+### Disable word timestamps
+
+Some models return plain text more reliably than timestamped hypotheses:
+
+```bash
+pdm run python -m scripts.evaluate_model run data/samples/sample_mono.wav \
+  --no-word-timestamps
+```
+
+### Custom baseline or candidate
+
+```bash
+pdm run python -m scripts.evaluate_model run data/samples/sample_mono.wav \
+  --baseline nvidia/parakeet-tdt-0.6b-v2 \
+  --candidate nvidia/parakeet-unified-en-0.6b
+```
+
+## Recording results
+
+When you have run an evaluation on a real ROCm/CUDA machine:
+
+1. Copy the generated Markdown report from
+   `data/evaluation_results/evaluation_<baseline>_vs_<candidate>.md`.
+2. Rename it with the date and hardware, for example
+   `2026-07-05_rtx4090_parakeet-tdt-0.6b-v3_vs_parakeet-unified-en-0.6b.md`.
+3. Place it in `docs/evaluation_results/`.
+4. Fill in the template fields at the top of the file.
+
+This keeps evaluation evidence under version control so the project can decide,
+based on reproducible data, whether to change the default model.
+
+## Tests
+
+GPU/integration tests for the unified model live in
+`tests/integration/test_unified_model.py`. They are marked `integration`, `gpu`,
+and `slow` and skip cleanly when no GPU or sample audio is available.
+
+Run only non-GPU tests locally:
+
+```bash
+pdm run pytest tests/integration/test_unified_model.py -m 'not gpu' -v
+```
+
+Run GPU tests on a machine with the model available:
+
+```bash
+pdm run pytest tests/integration/test_unified_model.py -m gpu -v
+```
+
+## Known limitations
+
+- The unified model may not expose word-level timestamps in the same format as
+  the Parakeet-TDT model. The evaluation script records compatibility rather
+  than failing; see `timestamp_compatible` and `timestamp_notes` in the JSON
+  report.
+- Full evaluation requires a ROCm/CUDA GPU and a network connection to download
+  the candidate model. Running without those resources produces skipped tests
+  and empty reports but does not break the suite.

--- a/scripts/evaluate_model.py
+++ b/scripts/evaluate_model.py
@@ -64,6 +64,7 @@ class ModelResult:
     segment_count: int = 0
     runtime_seconds: float = 0.0
     load_seconds: float = 0.0
+    audio_duration_sec: float = 0.0
     timestamp_compatible: bool = False
     timestamp_notes: str = ""
     output_paths: dict[str, str] = field(default_factory=dict)
@@ -144,7 +145,7 @@ def _collect_one(
     )
 
     try:
-        wav, sample_rate, segments, load_elapsed, duration_sec = _load_and_prepare_audio(
+        _wav, _sample_rate, segments, load_elapsed, duration_sec = _load_and_prepare_audio(
             audio_path=audio_path,
             chunk_len_sec=chunk_len_sec,
             overlap_duration=0,
@@ -157,6 +158,7 @@ def _collect_one(
         return result
 
     result.runtime_seconds = load_elapsed
+    result.audio_duration_sec = duration_sec
 
     try:
         t_infer = time.perf_counter()
@@ -276,7 +278,7 @@ def _compare(
     )
     clear_model_cache()
 
-    duration_sec = 0.0
+    duration_sec = max(baseline.audio_duration_sec, candidate.audio_duration_sec)
     notes: list[str] = []
 
     if baseline.transcription and candidate.transcription:

--- a/scripts/evaluate_model.py
+++ b/scripts/evaluate_model.py
@@ -1,0 +1,530 @@
+#!/usr/bin/env python3
+"""Compare two NeMo Parakeet ASR models on one or more audio files.
+
+The script transcribes the same audio with both a baseline model (default:
+``nvidia/parakeet-tdt-0.6b-v3``) and a candidate model, exercising the same
+pipeline the CLI uses: model loading, chunked transcription, word-level
+timestamps (when supported), benchmark metrics, and all built-in output
+formats. Results are written as JSON and Markdown for reproducible comparison.
+
+This is intentionally a standalone script rather than CLI subcommand so it can
+be evolved and run without changing the public CLI contract.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import sys
+import time
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+import typer
+
+from parakeet_rocm.benchmarks.collector import BenchmarkCollector
+from parakeet_rocm.formatting import FORMATTERS
+from parakeet_rocm.models.parakeet import clear_model_cache, get_model
+from parakeet_rocm.timestamps.adapt import adapt_nemo_hypotheses
+from parakeet_rocm.transcription.file_processor import _load_and_prepare_audio, _transcribe_batches
+from parakeet_rocm.transcription.utils import calc_time_stride, configure_environment
+from parakeet_rocm.utils.constant import (
+    BENCHMARK_OUTPUT_DIR,
+    DEFAULT_BATCH_SIZE,
+    DEFAULT_CHUNK_LEN_SEC,
+    PARAKEET_MODEL_NAME,
+    SUPPORTED_EXTENSIONS,
+)
+from parakeet_rocm.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+app = typer.Typer(add_completion=False, no_args_is_help=True)
+
+
+def _slugify(value: str) -> str:
+    """Convert a model name into a safe filename component.
+
+    Returns:
+        str: Sanitised model name safe for use in filenames.
+    """
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", value).strip("._-")
+    return cleaned or "model"
+
+
+@dataclass
+class ModelResult:
+    """Per-model transcription result and metadata."""
+
+    model_name: str
+    transcription: str = ""
+    word_count: int = 0
+    segment_count: int = 0
+    runtime_seconds: float = 0.0
+    load_seconds: float = 0.0
+    timestamp_compatible: bool = False
+    timestamp_notes: str = ""
+    output_paths: dict[str, str] = field(default_factory=dict)
+    error: str | None = None
+
+
+@dataclass
+class ComparisonResult:
+    """Comparison output for one audio file."""
+
+    audio_path: str
+    audio_duration_sec: float
+    baseline: ModelResult
+    candidate: ModelResult
+    text_similarity_ratio: float = 0.0
+    notes: list[str] = field(default_factory=list)
+
+
+@dataclass
+class EvaluationRun:
+    """Top-level result for the whole evaluation run."""
+
+    baseline_model: str
+    candidate_model: str
+    files: list[ComparisonResult] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+
+
+def _text_similarity(a: str, b: str) -> float:
+    """Return a simple normalised word overlap ratio between two strings."""
+    import difflib
+
+    a_norm = re.sub(r"\s+", " ", a.strip().lower())
+    b_norm = re.sub(r"\s+", " ", b.strip().lower())
+    if not a_norm and not b_norm:
+        return 1.0
+    if not a_norm or not b_norm:
+        return 0.0
+    return difflib.SequenceMatcher(None, a_norm, b_norm).ratio()
+
+
+def _collect_one(
+    audio_path: Path,
+    model_name: str,
+    output_dir: Path,
+    chunk_len_sec: int,
+    batch_size: int,
+    word_timestamps: bool,
+    formats: Sequence[str],
+) -> ModelResult:
+    """Transcribe a single audio file with one model and collect metrics.
+
+    Returns:
+        ModelResult: Transcription result, timing metrics, and output paths.
+    """
+    result = ModelResult(model_name=model_name)
+
+    t_load_start = time.perf_counter()
+    try:
+        model = get_model(model_name)
+    except Exception as exc:  # pragma: no cover - exercised in GPU integration tests
+        logger.exception("failed to load model %s", model_name)
+        result.error = f"load failed: {exc}"
+        return result
+    result.load_seconds = time.perf_counter() - t_load_start
+
+    collector = BenchmarkCollector(
+        output_dir=BENCHMARK_OUTPUT_DIR,
+        slug=f"eval_{_slugify(model_name)}_{audio_path.stem}",
+        config={
+            "model_name": model_name,
+            "batch_size": batch_size,
+            "chunk_len_sec": chunk_len_sec,
+            "word_timestamps": word_timestamps,
+        },
+        audio_path=str(audio_path),
+        task="evaluate_model",
+    )
+
+    try:
+        wav, sample_rate, segments, load_elapsed, duration_sec = _load_and_prepare_audio(
+            audio_path=audio_path,
+            chunk_len_sec=chunk_len_sec,
+            overlap_duration=0,
+            verbose=False,
+            quiet=True,
+        )
+    except Exception as exc:  # pragma: no cover - exercised in GPU integration tests
+        logger.exception("failed to load audio %s", audio_path)
+        result.error = f"audio load failed: {exc}"
+        return result
+
+    result.runtime_seconds = load_elapsed
+
+    try:
+        t_infer = time.perf_counter()
+        from rich.progress import Progress
+
+        with Progress(disable=True) as progress:
+            main_task = progress.add_task("transcribe", total=len(segments))
+            hypotheses, texts = _transcribe_batches(
+                model=model,
+                segments=segments,
+                batch_size=batch_size,
+                word_timestamps=word_timestamps,
+                progress=progress,
+                main_task=main_task,
+                no_progress=True,
+                batch_progress_callback=None,
+            )
+        result.runtime_seconds += time.perf_counter() - t_infer
+
+        if word_timestamps and hypotheses:
+            try:
+                time_stride = calc_time_stride(model, verbose=False)
+                aligned = adapt_nemo_hypotheses(hypotheses, model, time_stride)
+                result.transcription = " ".join(
+                    seg.text.replace("\n", " ") for seg in aligned.segments
+                )
+                result.word_count = len(aligned.word_segments)
+                result.segment_count = len(aligned.segments)
+                result.timestamp_compatible = True
+                result.timestamp_notes = "adapt_nemo_hypotheses succeeded"
+
+                for fmt in formats:
+                    spec = FORMATTERS.get(fmt)
+                    if spec is None:
+                        continue
+                    try:
+                        text = spec.format_func(aligned)
+                        out_path = output_dir / f"{audio_path.stem}_{_slugify(model_name)}.{fmt}"
+                        out_path.write_text(text, encoding="utf-8")
+                        result.output_paths[fmt] = str(out_path)
+                    except Exception as fmt_exc:  # pragma: no cover
+                        logger.warning(
+                            "format %s failed for %s: %s",
+                            fmt,
+                            model_name,
+                            fmt_exc,
+                        )
+            except Exception as exc:  # pragma: no cover - exercised in GPU tests
+                logger.exception("word timestamp adaptation failed for %s", model_name)
+                result.timestamp_compatible = False
+                result.timestamp_notes = f"word timestamp adaptation failed: {exc}"
+                result.transcription = ""
+                result.word_count = 0
+                result.segment_count = 0
+        elif texts:
+            result.transcription = " ".join(texts)
+            result.word_count = len(result.transcription.split())
+            result.segment_count = 0
+            result.timestamp_compatible = False
+            result.timestamp_notes = "plain text transcription (word timestamps disabled)"
+        else:
+            result.timestamp_notes = "no transcription output returned"
+
+    except Exception as exc:  # pragma: no cover - exercised in GPU integration tests
+        logger.exception("inference failed for %s on %s", model_name, audio_path)
+        result.error = f"inference failed: {exc}"
+
+    collector.metrics["runtime_seconds"] = result.runtime_seconds
+    collector.add_file_metrics(
+        filename=audio_path.name,
+        duration_sec=duration_sec,
+        segment_count=result.segment_count,
+        processing_time_sec=result.runtime_seconds,
+    )
+    try:
+        collector.write_json()
+    except Exception:  # pragma: no cover
+        logger.debug("benchmark write failed", exc_info=True)
+
+    return result
+
+
+def _compare(
+    audio_path: Path,
+    baseline_name: str,
+    candidate_name: str,
+    output_dir: Path,
+    chunk_len_sec: int,
+    batch_size: int,
+    word_timestamps: bool,
+    formats: Sequence[str],
+) -> ComparisonResult:
+    """Run both models on one audio file and compare.
+
+    Returns:
+        ComparisonResult: Side-by-side result for the audio file.
+    """
+    clear_model_cache()
+    baseline = _collect_one(
+        audio_path,
+        baseline_name,
+        output_dir,
+        chunk_len_sec=chunk_len_sec,
+        batch_size=batch_size,
+        word_timestamps=word_timestamps,
+        formats=formats,
+    )
+    clear_model_cache()
+    candidate = _collect_one(
+        audio_path,
+        candidate_name,
+        output_dir,
+        chunk_len_sec=chunk_len_sec,
+        batch_size=batch_size,
+        word_timestamps=word_timestamps,
+        formats=formats,
+    )
+    clear_model_cache()
+
+    duration_sec = 0.0
+    notes: list[str] = []
+
+    if baseline.transcription and candidate.transcription:
+        similarity = _text_similarity(baseline.transcription, candidate.transcription)
+    else:
+        similarity = 0.0
+        if baseline.error:
+            notes.append(f"baseline error: {baseline.error}")
+        if candidate.error:
+            notes.append(f"candidate error: {candidate.error}")
+        if not baseline.transcription and not baseline.error:
+            notes.append("baseline produced empty transcription")
+        if not candidate.transcription and not candidate.error:
+            notes.append("candidate produced empty transcription")
+
+    if baseline.timestamp_compatible != candidate.timestamp_compatible:
+        notes.append(
+            "timestamp compatibility differs: baseline="
+            f"{baseline.timestamp_compatible}, candidate={candidate.timestamp_compatible}"
+        )
+
+    return ComparisonResult(
+        audio_path=str(audio_path),
+        audio_duration_sec=duration_sec,
+        baseline=baseline,
+        candidate=candidate,
+        text_similarity_ratio=similarity,
+        notes=notes,
+    )
+
+
+def _serialise(obj: object) -> object:
+    """Convert dataclasses and paths to JSON-safe structures.
+
+    Args:
+        obj: Object to serialise.
+
+    Returns:
+        JSON-safe representation of ``obj``.
+    """
+    if isinstance(obj, Path):
+        return str(obj)
+    if isinstance(obj, ModelResult):
+        return asdict(obj)
+    if isinstance(obj, ComparisonResult):
+        return asdict(obj)
+    if isinstance(obj, EvaluationRun):
+        return asdict(obj)
+    return obj
+
+
+def _write_json(run: EvaluationRun, output_dir: Path) -> Path:
+    """Write the evaluation run as JSON.
+
+    Returns:
+        Path: Path to the written JSON report.
+    """
+    slug_baseline = _slugify(run.baseline_model)
+    slug_candidate = _slugify(run.candidate_model)
+    out = output_dir / f"evaluation_{slug_baseline}_vs_{slug_candidate}.json"
+    out.write_text(
+        json.dumps(run, default=_serialise, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return out
+
+
+def _write_markdown(run: EvaluationRun, output_dir: Path) -> Path:
+    """Write a human-readable Markdown report.
+
+    Returns:
+        Path: Path to the written Markdown report.
+    """
+    slug_baseline = _slugify(run.baseline_model)
+    slug_candidate = _slugify(run.candidate_model)
+    out = output_dir / f"evaluation_{slug_baseline}_vs_{slug_candidate}.md"
+    lines: list[str] = [
+        "# Model evaluation report",
+        "",
+        f"- Baseline: `{run.baseline_model}`",
+        f"- Candidate: `{run.candidate_model}`",
+        "",
+    ]
+    if run.notes:
+        lines.extend(["## Run-level notes", "", *(f"- {note}" for note in run.notes), ""])
+
+    for result in run.files:
+        lines.extend([
+            f"## {Path(result.audio_path).name}",
+            "",
+            f"Duration: {result.audio_duration_sec:.2f}s",
+            f"Text similarity ratio: {result.text_similarity_ratio:.3f}",
+            "",
+            "### Baseline",
+            "",
+            f"- Model: `{result.baseline.model_name}`",
+            f"- Runtime: {result.baseline.runtime_seconds:.2f}s",
+            f"- Load time: {result.baseline.load_seconds:.2f}s",
+            f"- Word count: {result.baseline.word_count}",
+            f"- Segment count: {result.baseline.segment_count}",
+            f"- Timestamp compatible: {result.baseline.timestamp_compatible}",
+            f"- Timestamp notes: {result.baseline.timestamp_notes}",
+            f"- Error: {result.baseline.error or 'none'}",
+            "",
+            "### Candidate",
+            "",
+            f"- Model: `{result.candidate.model_name}`",
+            f"- Runtime: {result.candidate.runtime_seconds:.2f}s",
+            f"- Load time: {result.candidate.load_seconds:.2f}s",
+            f"- Word count: {result.candidate.word_count}",
+            f"- Segment count: {result.candidate.segment_count}",
+            f"- Timestamp compatible: {result.candidate.timestamp_compatible}",
+            f"- Timestamp notes: {result.candidate.timestamp_notes}",
+            f"- Error: {result.candidate.error or 'none'}",
+            "",
+        ])
+        if result.baseline.output_paths:
+            lines.extend(["#### Baseline output files", ""])
+            for fmt, path in sorted(result.baseline.output_paths.items()):
+                lines.append(f"- {fmt}: `{path}`")
+            lines.append("")
+        if result.candidate.output_paths:
+            lines.extend(["#### Candidate output files", ""])
+            for fmt, path in sorted(result.candidate.output_paths.items()):
+                lines.append(f"- {fmt}: `{path}`")
+            lines.append("")
+        if result.notes:
+            lines.extend(["### Comparison notes", "", *(f"- {note}" for note in result.notes), ""])
+
+    out.write_text("\n".join(lines), encoding="utf-8")
+    return out
+
+
+@app.command("run")
+def run_evaluation(
+    audio: Path = typer.Argument(
+        ...,
+        help="Path to an audio file or directory of audio files.",
+        exists=True,
+        file_okay=True,
+        dir_okay=True,
+        readable=True,
+    ),
+    baseline: str = typer.Option(
+        PARAKEET_MODEL_NAME,
+        "--baseline",
+        help="Baseline Parakeet model name.",
+    ),
+    candidate: str = typer.Option(
+        "nvidia/parakeet-unified-en-0.6b",
+        "--candidate",
+        help="Candidate Parakeet model name to evaluate.",
+    ),
+    output_dir: Path = typer.Option(
+        Path("data/evaluation_results"),
+        "--output-dir",
+        help="Directory for JSON/Markdown reports and per-format outputs.",
+    ),
+    chunk_len_sec: int = typer.Option(
+        DEFAULT_CHUNK_LEN_SEC,
+        "--chunk-len-sec",
+        help="Chunk length in seconds.",
+    ),
+    batch_size: int = typer.Option(
+        DEFAULT_BATCH_SIZE,
+        "--batch-size",
+        help="Batch size for model inference.",
+    ),
+    word_timestamps: bool = typer.Option(
+        True,
+        "--word-timestamps/--no-word-timestamps",
+        help="Request word-level timestamps from the model.",
+    ),
+    formats: str = typer.Option(
+        "txt,json,jsonl,csv,tsv,srt,vtt",
+        "--formats",
+        help="Comma-separated list of output formats to exercise.",
+    ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        "-v",
+        help="Enable verbose logging.",
+    ),
+) -> None:
+    """Compare baseline and candidate ASR models on the provided audio.
+
+    Writes a JSON report and a Markdown report to ``--output-dir``.
+
+    Raises:
+        typer.Exit: If an invalid output format is requested or no audio files
+            are found.
+    """
+    log_level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=log_level)
+    configure_environment(verbose)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    requested_formats = [fmt.strip().lower() for fmt in formats.split(",") if fmt.strip()]
+    invalid_formats = [fmt for fmt in requested_formats if fmt not in FORMATTERS]
+    if invalid_formats:
+        typer.echo(f"Unsupported formats: {invalid_formats}", err=True)
+        raise typer.Exit(code=2)
+
+    if audio.is_file():
+        audio_files = [audio]
+    else:
+        audio_files = sorted(
+            p for p in audio.iterdir() if p.is_file() and p.suffix.lower() in SUPPORTED_EXTENSIONS
+        )
+        if not audio_files:
+            typer.echo(f"No supported audio files found in {audio}", err=True)
+            raise typer.Exit(code=2)
+
+    run = EvaluationRun(baseline_model=baseline, candidate_model=candidate)
+
+    for audio_path in audio_files:
+        logger.info("evaluating %s", audio_path)
+        comparison = _compare(
+            audio_path=audio_path,
+            baseline_name=baseline,
+            candidate_name=candidate,
+            output_dir=output_dir,
+            chunk_len_sec=chunk_len_sec,
+            batch_size=batch_size,
+            word_timestamps=word_timestamps,
+            formats=requested_formats,
+        )
+        run.files.append(comparison)
+
+    if not run.files:
+        run.notes.append("no files processed")
+
+    json_path = _write_json(run, output_dir)
+    md_path = _write_markdown(run, output_dir)
+    logger.info("wrote JSON report: %s", json_path)
+    logger.info("wrote Markdown report: %s", md_path)
+
+
+def main() -> None:
+    """Entrypoint for ``python -m scripts.evaluate_model``."""
+    app()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        logger.warning("interrupted by user")
+        sys.exit(130)

--- a/tests/integration/test_unified_model.py
+++ b/tests/integration/test_unified_model.py
@@ -1,15 +1,17 @@
 """Integration tests for the nvidia/parakeet-unified-en-0.6b model.
 
-These tests exercise the same loading and transcription paths the CLI uses,
-but are marked ``gpu`` and ``slow`` because they require a ROCm/CUDA-capable
-device and a network model download. They skip cleanly when those
-prerequisites are unavailable, so they can live in the suite without breaking
-local or CI runs that lack GPU/model access.
+GPU-dependent tests are marked ``gpu`` and ``slow`` because they require a
+ROCm/CUDA-capable device and a network model download. They skip cleanly when
+those prerequisites are unavailable, so they can live in the suite without
+breaking local or CI runs that lack GPU/model access. The non-GPU availability
+test still runs in ordinary CI.
 """
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -18,11 +20,7 @@ AUDIO_PATH = Path(__file__).parents[2] / "data" / "samples" / "sample_mono.wav"
 
 UNIFIED_MODEL_NAME = "nvidia/parakeet-unified-en-0.6b"
 
-pytestmark = [
-    pytest.mark.integration,
-    pytest.mark.gpu,
-    pytest.mark.slow,
-]
+_IN_CI = os.getenv("CI") == "true"
 
 
 def _gpu_available() -> bool:
@@ -37,175 +35,176 @@ def _gpu_available() -> bool:
         return False
 
 
+def _audio_skip() -> pytest.MarkDecorator:
+    """Return a pytest skip mark for missing sample audio."""
+    return pytest.mark.skipif(
+        not AUDIO_PATH.is_file(),
+        reason=f"sample audio not present at {AUDIO_PATH}",
+    )
+
+
+_GPU_SKIP = pytest.mark.skipif(
+    not _gpu_available(),
+    reason="GPU test skipped because torch reports no CUDA/ROCm device",
+)
+_AUDIO_SKIP = _audio_skip()
+_CI_SKIP = pytest.mark.skipif(
+    _IN_CI,
+    reason="GPU tests are skipped in CI",
+)
+
+
 def _model_name_for_test() -> str:
     """Allow env override for the unified model under test.
 
     Returns:
         str: Model name to load during the test.
     """
-    import os
-
     return os.getenv("PARAKEET_UNIFIED_MODEL_NAME", UNIFIED_MODEL_NAME)
 
 
-@pytest.mark.skipif(
-    not _gpu_available(),
-    reason="GPU test skipped because torch reports no CUDA/ROCm device",
-)
-@pytest.mark.skipif(
-    not AUDIO_PATH.is_file(),
-    reason=f"sample audio not present at {AUDIO_PATH}",
-)
-def test_unified_model_loads() -> None:
-    """Verify the unified model can be loaded via the project's model accessor."""
+@pytest.fixture
+def loaded_unified_model() -> Any:  # noqa: ANN401
+    """Load the unified model and guarantee cache cleanup on teardown.
+
+    Yields:
+        The loaded model object.
+    """
     from parakeet_rocm.models.parakeet import clear_model_cache, get_model
 
     model_name = _model_name_for_test()
     clear_model_cache()
     try:
         model = get_model(model_name)
+        yield model
     finally:
         clear_model_cache()
 
-    assert model is not None
-    assert hasattr(model, "transcribe")
 
+@pytest.fixture
+def prepared_audio() -> Any:  # noqa: ANN401
+    """Load sample audio and return the waveform plus segment list.
 
-@pytest.mark.skipif(
-    not _gpu_available(),
-    reason="GPU test skipped because torch reports no CUDA/ROCm device",
-)
-@pytest.mark.skipif(
-    not AUDIO_PATH.is_file(),
-    reason=f"sample audio not present at {AUDIO_PATH}",
-)
-def test_unified_model_transcribes_plain_text() -> None:
-    """Verify the unified model returns non-empty plain text on sample audio."""
-    from parakeet_rocm.models.parakeet import clear_model_cache, get_model
+    Yields:
+        Tuple of ``(wav, segments)``.
+    """
     from parakeet_rocm.transcription.file_processor import _load_and_prepare_audio
 
-    model_name = _model_name_for_test()
-    clear_model_cache()
-    try:
-        model = get_model(model_name)
-        wav, sample_rate, segments, _load_elapsed, _duration = _load_and_prepare_audio(
-            audio_path=AUDIO_PATH,
-            chunk_len_sec=30,
-            overlap_duration=0,
-            verbose=False,
-            quiet=True,
-        )
-        results = model.transcribe(
-            audio=[wav],
-            batch_size=1,
-            return_hypotheses=False,
-            verbose=False,
-        )
-    finally:
-        clear_model_cache()
+    wav, _sample_rate, segments, _load_elapsed, _duration = _load_and_prepare_audio(
+        audio_path=AUDIO_PATH,
+        chunk_len_sec=30,
+        overlap_duration=0,
+        verbose=False,
+        quiet=True,
+    )
+    yield wav, segments
+
+
+@_CI_SKIP
+@_GPU_SKIP
+@_AUDIO_SKIP
+@pytest.mark.gpu
+@pytest.mark.slow
+def test_get_model__loads_unified_model(loaded_unified_model: Any) -> None:  # noqa: ANN401
+    """Verify the unified model can be loaded via the project's model accessor."""
+    assert loaded_unified_model is not None
+    assert hasattr(loaded_unified_model, "transcribe")
+
+
+@_CI_SKIP
+@_GPU_SKIP
+@_AUDIO_SKIP
+@pytest.mark.gpu
+@pytest.mark.slow
+def test_transcribe__returns_non_empty_plain_text_for_unified_model(
+    loaded_unified_model: Any,  # noqa: ANN401
+    prepared_audio: Any,  # noqa: ANN401
+) -> None:
+    """Verify the unified model returns non-empty plain text on sample audio."""
+    wav, _segments = prepared_audio
+    results = loaded_unified_model.transcribe(
+        audio=[wav],
+        batch_size=1,
+        return_hypotheses=False,
+        verbose=False,
+    )
 
     assert results
     text = results[0].text if hasattr(results[0], "text") else str(results[0])
     assert text.strip(), "unified model returned empty transcription"
 
 
-@pytest.mark.skipif(
-    not _gpu_available(),
-    reason="GPU test skipped because torch reports no CUDA/ROCm device",
-)
-@pytest.mark.skipif(
-    not AUDIO_PATH.is_file(),
-    reason=f"sample audio not present at {AUDIO_PATH}",
-)
-def test_unified_model_word_timestamps_compatible() -> None:
+@_CI_SKIP
+@_GPU_SKIP
+@_AUDIO_SKIP
+@pytest.mark.gpu
+@pytest.mark.slow
+def test_adapt_nemo_hypotheses__does_not_crash_for_unified_model(
+    loaded_unified_model: Any,  # noqa: ANN401
+    prepared_audio: Any,  # noqa: ANN401
+) -> None:
     """Verify the unified model's hypotheses can be adapted to word timestamps."""
-    from parakeet_rocm.models.parakeet import clear_model_cache, get_model
     from parakeet_rocm.timestamps.adapt import adapt_nemo_hypotheses
-    from parakeet_rocm.transcription.file_processor import _load_and_prepare_audio
     from parakeet_rocm.transcription.utils import calc_time_stride
 
-    model_name = _model_name_for_test()
-    clear_model_cache()
-    try:
-        model = get_model(model_name)
-        wav, _sample_rate, segments, _load_elapsed, _duration = _load_and_prepare_audio(
-            audio_path=AUDIO_PATH,
-            chunk_len_sec=30,
-            overlap_duration=0,
-            verbose=False,
-            quiet=True,
-        )
-        results = model.transcribe(
-            audio=[wav],
-            batch_size=1,
-            return_hypotheses=True,
-            verbose=False,
-        )
+    wav, _segments = prepared_audio
+    results = loaded_unified_model.transcribe(
+        audio=[wav],
+        batch_size=1,
+        return_hypotheses=True,
+        verbose=False,
+    )
 
-        time_stride = calc_time_stride(model, verbose=False)
-        hypotheses = [results[0]] if not isinstance(results, list) else results
-        for hyp in hypotheses:
-            setattr(hyp, "start_offset", 0.0)
-        aligned = adapt_nemo_hypotheses(hypotheses, model, time_stride)
-    finally:
-        clear_model_cache()
+    time_stride = calc_time_stride(loaded_unified_model, verbose=False)
+    hypotheses = [results[0]] if not isinstance(results, list) else results
+    for hyp in hypotheses:
+        hyp.start_offset = 0.0
+    aligned = adapt_nemo_hypotheses(hypotheses, loaded_unified_model, time_stride)
 
     assert aligned is not None
     # We do not require word timestamps; unified models may not expose them.
     # The important contract is that the adapter does not crash.
 
 
+@_CI_SKIP
+@_GPU_SKIP
+@_AUDIO_SKIP
+@pytest.mark.gpu
+@pytest.mark.slow
 @pytest.mark.parametrize("fmt", ["txt", "json", "jsonl", "csv", "tsv", "srt", "vtt"])
-@pytest.mark.skipif(
-    not _gpu_available(),
-    reason="GPU test skipped because torch reports no CUDA/ROCm device",
-)
-@pytest.mark.skipif(
-    not AUDIO_PATH.is_file(),
-    reason=f"sample audio not present at {AUDIO_PATH}",
-)
-def test_unified_model_output_formats(fmt: str, tmp_path: Path) -> None:
+def test_output_formatter__renders_unified_model_result(
+    fmt: str,
+    tmp_path: Path,
+    loaded_unified_model: Any,  # noqa: ANN401
+    prepared_audio: Any,  # noqa: ANN401
+) -> None:
     """Verify every required output formatter accepts the unified model result."""
     from parakeet_rocm.formatting import FORMATTERS, get_formatter_spec
-    from parakeet_rocm.models.parakeet import clear_model_cache, get_model
     from parakeet_rocm.timestamps.adapt import adapt_nemo_hypotheses
-    from parakeet_rocm.transcription.file_processor import _load_and_prepare_audio
     from parakeet_rocm.transcription.utils import calc_time_stride
 
     assert fmt in FORMATTERS, f"requested format {fmt} is not registered"
 
-    model_name = _model_name_for_test()
-    clear_model_cache()
-    try:
-        model = get_model(model_name)
-        wav, _sample_rate, _segments, _load_elapsed, _duration = _load_and_prepare_audio(
-            audio_path=AUDIO_PATH,
-            chunk_len_sec=30,
-            overlap_duration=0,
-            verbose=False,
-            quiet=True,
-        )
-        results = model.transcribe(
-            audio=[wav],
-            batch_size=1,
-            return_hypotheses=True,
-            verbose=False,
-        )
+    wav, _segments = prepared_audio
+    results = loaded_unified_model.transcribe(
+        audio=[wav],
+        batch_size=1,
+        return_hypotheses=True,
+        verbose=False,
+    )
 
-        hypotheses = [results[0]] if not isinstance(results, list) else results
-        for hyp in hypotheses:
-            setattr(hyp, "start_offset", 0.0)
-        time_stride = calc_time_stride(model, verbose=False)
-        aligned = adapt_nemo_hypotheses(hypotheses, model, time_stride)
+    hypotheses = [results[0]] if not isinstance(results, list) else results
+    for hyp in hypotheses:
+        hyp.start_offset = 0.0
+    time_stride = calc_time_stride(loaded_unified_model, verbose=False)
+    aligned = adapt_nemo_hypotheses(hypotheses, loaded_unified_model, time_stride)
 
-        spec = get_formatter_spec(fmt)
-        if spec.requires_word_timestamps and not aligned.word_segments:
-            pytest.skip(f"unified model produced no word timestamps; format {fmt} cannot be tested")
+    spec = get_formatter_spec(fmt)
+    if spec.requires_word_timestamps and not aligned.word_segments:
+        pytest.skip(f"unified model produced no word timestamps; format {fmt} cannot be tested")
 
-        formatter = spec.format_func
-        rendered = formatter(aligned)
-    finally:
-        clear_model_cache()
+    formatter = spec.format_func
+    rendered = formatter(aligned)
 
     assert rendered is not None
     out_path = tmp_path / f"unified.{fmt}"
@@ -213,11 +212,11 @@ def test_unified_model_output_formats(fmt: str, tmp_path: Path) -> None:
     assert out_path.read_text(encoding="utf-8") == rendered
 
 
-def test_unified_model_skips_cleanly_without_gpu() -> None:
-    """Guard: ensure skip detection returns False when torch is missing or no GPU."""
-    # This function deliberately does not import project modules. It exists only
-    # to exercise _gpu_available() in an environment without torch/GPU.
-    assert _gpu_available() is False or True  # Trivial: function must be callable.
+@pytest.mark.integration
+def test_gpu_availability__reports_bool_without_torch_or_gpu() -> None:
+    """Guard: ensure skip detection returns a boolean and does not raise."""
+    available = _gpu_available()
+    assert isinstance(available, bool)  # type: ignore[no-any-return]
 
 
 # Explicit ``__all__`` keeps the public surface minimal.
@@ -226,9 +225,11 @@ __all__ = [
     "UNIFIED_MODEL_NAME",
     "_gpu_available",
     "_model_name_for_test",
-    "test_unified_model_loads",
-    "test_unified_model_transcribes_plain_text",
-    "test_unified_model_word_timestamps_compatible",
-    "test_unified_model_output_formats",
-    "test_unified_model_skips_cleanly_without_gpu",
+    "loaded_unified_model",
+    "prepared_audio",
+    "test_get_model__loads_unified_model",
+    "test_transcribe__returns_non_empty_plain_text_for_unified_model",
+    "test_adapt_nemo_hypotheses__does_not_crash_for_unified_model",
+    "test_output_formatter__renders_unified_model_result",
+    "test_gpu_availability__reports_bool_without_torch_or_gpu",
 ]

--- a/tests/integration/test_unified_model.py
+++ b/tests/integration/test_unified_model.py
@@ -1,0 +1,234 @@
+"""Integration tests for the nvidia/parakeet-unified-en-0.6b model.
+
+These tests exercise the same loading and transcription paths the CLI uses,
+but are marked ``gpu`` and ``slow`` because they require a ROCm/CUDA-capable
+device and a network model download. They skip cleanly when those
+prerequisites are unavailable, so they can live in the suite without breaking
+local or CI runs that lack GPU/model access.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# Shared sample audio path used elsewhere in the integration suite.
+AUDIO_PATH = Path(__file__).parents[2] / "data" / "samples" / "sample_mono.wav"
+
+UNIFIED_MODEL_NAME = "nvidia/parakeet-unified-en-0.6b"
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.gpu,
+    pytest.mark.slow,
+]
+
+
+def _gpu_available() -> bool:
+    """Return whether a GPU usable by torch is present."""
+    try:
+        import torch
+    except (ModuleNotFoundError, OSError, RuntimeError):
+        return False
+    try:
+        return bool(torch.cuda.is_available())
+    except (OSError, RuntimeError):
+        return False
+
+
+def _model_name_for_test() -> str:
+    """Allow env override for the unified model under test.
+
+    Returns:
+        str: Model name to load during the test.
+    """
+    import os
+
+    return os.getenv("PARAKEET_UNIFIED_MODEL_NAME", UNIFIED_MODEL_NAME)
+
+
+@pytest.mark.skipif(
+    not _gpu_available(),
+    reason="GPU test skipped because torch reports no CUDA/ROCm device",
+)
+@pytest.mark.skipif(
+    not AUDIO_PATH.is_file(),
+    reason=f"sample audio not present at {AUDIO_PATH}",
+)
+def test_unified_model_loads() -> None:
+    """Verify the unified model can be loaded via the project's model accessor."""
+    from parakeet_rocm.models.parakeet import clear_model_cache, get_model
+
+    model_name = _model_name_for_test()
+    clear_model_cache()
+    try:
+        model = get_model(model_name)
+    finally:
+        clear_model_cache()
+
+    assert model is not None
+    assert hasattr(model, "transcribe")
+
+
+@pytest.mark.skipif(
+    not _gpu_available(),
+    reason="GPU test skipped because torch reports no CUDA/ROCm device",
+)
+@pytest.mark.skipif(
+    not AUDIO_PATH.is_file(),
+    reason=f"sample audio not present at {AUDIO_PATH}",
+)
+def test_unified_model_transcribes_plain_text() -> None:
+    """Verify the unified model returns non-empty plain text on sample audio."""
+    from parakeet_rocm.models.parakeet import clear_model_cache, get_model
+    from parakeet_rocm.transcription.file_processor import _load_and_prepare_audio
+
+    model_name = _model_name_for_test()
+    clear_model_cache()
+    try:
+        model = get_model(model_name)
+        wav, sample_rate, segments, _load_elapsed, _duration = _load_and_prepare_audio(
+            audio_path=AUDIO_PATH,
+            chunk_len_sec=30,
+            overlap_duration=0,
+            verbose=False,
+            quiet=True,
+        )
+        results = model.transcribe(
+            audio=[wav],
+            batch_size=1,
+            return_hypotheses=False,
+            verbose=False,
+        )
+    finally:
+        clear_model_cache()
+
+    assert results
+    text = results[0].text if hasattr(results[0], "text") else str(results[0])
+    assert text.strip(), "unified model returned empty transcription"
+
+
+@pytest.mark.skipif(
+    not _gpu_available(),
+    reason="GPU test skipped because torch reports no CUDA/ROCm device",
+)
+@pytest.mark.skipif(
+    not AUDIO_PATH.is_file(),
+    reason=f"sample audio not present at {AUDIO_PATH}",
+)
+def test_unified_model_word_timestamps_compatible() -> None:
+    """Verify the unified model's hypotheses can be adapted to word timestamps."""
+    from parakeet_rocm.models.parakeet import clear_model_cache, get_model
+    from parakeet_rocm.timestamps.adapt import adapt_nemo_hypotheses
+    from parakeet_rocm.transcription.file_processor import _load_and_prepare_audio
+    from parakeet_rocm.transcription.utils import calc_time_stride
+
+    model_name = _model_name_for_test()
+    clear_model_cache()
+    try:
+        model = get_model(model_name)
+        wav, _sample_rate, segments, _load_elapsed, _duration = _load_and_prepare_audio(
+            audio_path=AUDIO_PATH,
+            chunk_len_sec=30,
+            overlap_duration=0,
+            verbose=False,
+            quiet=True,
+        )
+        results = model.transcribe(
+            audio=[wav],
+            batch_size=1,
+            return_hypotheses=True,
+            verbose=False,
+        )
+
+        time_stride = calc_time_stride(model, verbose=False)
+        hypotheses = [results[0]] if not isinstance(results, list) else results
+        for hyp in hypotheses:
+            setattr(hyp, "start_offset", 0.0)
+        aligned = adapt_nemo_hypotheses(hypotheses, model, time_stride)
+    finally:
+        clear_model_cache()
+
+    assert aligned is not None
+    # We do not require word timestamps; unified models may not expose them.
+    # The important contract is that the adapter does not crash.
+
+
+@pytest.mark.parametrize("fmt", ["txt", "json", "jsonl", "csv", "tsv", "srt", "vtt"])
+@pytest.mark.skipif(
+    not _gpu_available(),
+    reason="GPU test skipped because torch reports no CUDA/ROCm device",
+)
+@pytest.mark.skipif(
+    not AUDIO_PATH.is_file(),
+    reason=f"sample audio not present at {AUDIO_PATH}",
+)
+def test_unified_model_output_formats(fmt: str, tmp_path: Path) -> None:
+    """Verify every required output formatter accepts the unified model result."""
+    from parakeet_rocm.formatting import FORMATTERS, get_formatter_spec
+    from parakeet_rocm.models.parakeet import clear_model_cache, get_model
+    from parakeet_rocm.timestamps.adapt import adapt_nemo_hypotheses
+    from parakeet_rocm.transcription.file_processor import _load_and_prepare_audio
+    from parakeet_rocm.transcription.utils import calc_time_stride
+
+    assert fmt in FORMATTERS, f"requested format {fmt} is not registered"
+
+    model_name = _model_name_for_test()
+    clear_model_cache()
+    try:
+        model = get_model(model_name)
+        wav, _sample_rate, _segments, _load_elapsed, _duration = _load_and_prepare_audio(
+            audio_path=AUDIO_PATH,
+            chunk_len_sec=30,
+            overlap_duration=0,
+            verbose=False,
+            quiet=True,
+        )
+        results = model.transcribe(
+            audio=[wav],
+            batch_size=1,
+            return_hypotheses=True,
+            verbose=False,
+        )
+
+        hypotheses = [results[0]] if not isinstance(results, list) else results
+        for hyp in hypotheses:
+            setattr(hyp, "start_offset", 0.0)
+        time_stride = calc_time_stride(model, verbose=False)
+        aligned = adapt_nemo_hypotheses(hypotheses, model, time_stride)
+
+        spec = get_formatter_spec(fmt)
+        if spec.requires_word_timestamps and not aligned.word_segments:
+            pytest.skip(f"unified model produced no word timestamps; format {fmt} cannot be tested")
+
+        formatter = spec.format_func
+        rendered = formatter(aligned)
+    finally:
+        clear_model_cache()
+
+    assert rendered is not None
+    out_path = tmp_path / f"unified.{fmt}"
+    out_path.write_text(rendered, encoding="utf-8")
+    assert out_path.read_text(encoding="utf-8") == rendered
+
+
+def test_unified_model_skips_cleanly_without_gpu() -> None:
+    """Guard: ensure skip detection returns False when torch is missing or no GPU."""
+    # This function deliberately does not import project modules. It exists only
+    # to exercise _gpu_available() in an environment without torch/GPU.
+    assert _gpu_available() is False or True  # Trivial: function must be callable.
+
+
+# Explicit ``__all__`` keeps the public surface minimal.
+__all__ = [
+    "AUDIO_PATH",
+    "UNIFIED_MODEL_NAME",
+    "_gpu_available",
+    "_model_name_for_test",
+    "test_unified_model_loads",
+    "test_unified_model_transcribes_plain_text",
+    "test_unified_model_word_timestamps_compatible",
+    "test_unified_model_output_formats",
+    "test_unified_model_skips_cleanly_without_gpu",
+]


### PR DESCRIPTION
Adds reproducible evaluation tooling, integration tests, and documentation for comparing the default Parakeet model with "nvidia/parakeet-unified-en-0.6b" as requested in #41.

**What changed**
- "scripts/evaluate_model.py" - standalone comparison script that loads both models through the existing get_model() path, runs chunked transcription, exercises word-timestamp adaptation, writes JSON + Markdown reports, and renders all supported output formats (txt/json/jsonl/csv/tsv/srt/vtt).
- "tests/integration/test_unified_model.py" - integration tests marked integration/gpu/slow that skip cleanly when no GPU or sample audio is available.
- "docs/model_evaluation.md" - usage guide and commands.
- "docs/evaluation_results/model-comparison-template.md" + ".gitkeep" - template for recording real evaluation runs.

**Verification**
- "ruff check" and "ruff format" pass on the new files.
- "pytest tests/integration/test_unified_model.py" passes locally: 1 passed, 10 skipped (no GPU/torch in this environment).
- Full GPU/model evaluation could not be run locally; the tests and script are designed to skip/fail cleanly until run on a ROCm machine.

Closes #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line evaluation tool to benchmark and compare two ASR models using the same audio inputs.
  * Produces JSON and human-readable Markdown summaries, including per-audio comparison details and optional formatted transcription outputs.

* **Tests**
  * Added GPU-aware integration tests for unified model loading, transcription output, hypothesis/timestamp adaptation, and multi-format rendering.
  * Tests skip cleanly when hardware or required sample audio isn’t available, and verify deterministic formatted output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->