### PR TITLE
fix 🐛: Offload API model before switching

### DIFF
--- a/parakeet_rocm/api/app.py
+++ b/parakeet_rocm/api/app.py
@@ -31,10 +31,8 @@ def _warmup_api_model_cache() -> None:
     This is a best-effort operation and must not fail server startup.
     """
     try:
-        from parakeet_rocm.models.parakeet import get_model
-
         logger.info("API model warmup started for model=%s", API_MODEL_NAME)
-        get_model(API_MODEL_NAME)
+        api_routes.get_api_model(API_MODEL_NAME)
         logger.info("API model warmup completed for model=%s", API_MODEL_NAME)
     except Exception:
         logger.exception("API model warmup failed; continuing without warm cache")
@@ -55,8 +53,6 @@ def _start_api_idle_offload_thread() -> None:
     """Start API idle offload loop to keep VRAM usage low between requests."""
 
     def _worker() -> None:
-        from parakeet_rocm.models.parakeet import clear_model_cache, unload_model_to_cpu
-
         unloaded = False
         cleared = False
         while True:
@@ -67,10 +63,10 @@ def _start_api_idle_offload_thread() -> None:
                 else:
                     idle_for = time.monotonic() - api_routes.get_last_api_activity_monotonic()
                     if not unloaded and idle_for >= IDLE_UNLOAD_TIMEOUT_SEC:
-                        unload_model_to_cpu(API_MODEL_NAME)
+                        api_routes.unload_active_api_model()
                         unloaded = True
                     if not cleared and idle_for >= IDLE_CLEAR_TIMEOUT_SEC:
-                        clear_model_cache()
+                        api_routes.clear_api_model_cache()
                         cleared = True
             except Exception:
                 logger.debug("API idle offload loop iteration failed", exc_info=True)

--- a/parakeet_rocm/api/routes.py
+++ b/parakeet_rocm/api/routes.py
@@ -31,7 +31,7 @@ from parakeet_rocm.api.schemas import (
 )
 from parakeet_rocm.config import OutputConfig, StabilizationConfig, TranscriptionConfig
 from parakeet_rocm.formatting import UnsupportedFormatError
-from parakeet_rocm.models.parakeet import get_model
+from parakeet_rocm.models.parakeet import clear_model_cache, get_model, unload_model_to_cpu
 from parakeet_rocm.timestamps.models import AlignedResult
 from parakeet_rocm.transcription import cli_transcribe
 from parakeet_rocm.utils.constant import API_DEFAULT_BATCH_SIZE, API_DEFAULT_CHUNK_LEN_SEC
@@ -45,6 +45,8 @@ router = APIRouter()
 _activity_lock = threading.RLock()
 _last_api_activity_monotonic = monotonic()
 _active_api_requests = 0
+_api_model_lock = threading.Lock()
+_active_api_model_name: str | None = None
 
 
 def mark_api_activity() -> None:
@@ -88,6 +90,46 @@ def has_active_api_requests() -> bool:
     """
     with _activity_lock:
         return _active_api_requests > 0
+
+
+def get_api_model(model_name: str) -> object:
+    """Return an API model after offloading a previously active model.
+
+    Args:
+        model_name: Identifier of the model selected by the API request.
+
+    Returns:
+        Requested model placed on the preferred device.
+    """
+    global _active_api_model_name
+    with _api_model_lock:
+        previous_model_name = _active_api_model_name
+        if previous_model_name is not None and previous_model_name != model_name:
+            logger.info(
+                "API model changed: offloading model=%s before loading model=%s",
+                previous_model_name,
+                model_name,
+            )
+            unload_model_to_cpu(previous_model_name)
+
+        model = get_model(model_name)
+        _active_api_model_name = model_name
+        return model
+
+
+def unload_active_api_model() -> None:
+    """Offload the active API model without loading a cache miss."""
+    with _api_model_lock:
+        if _active_api_model_name is not None:
+            unload_model_to_cpu(_active_api_model_name)
+
+
+def clear_api_model_cache() -> None:
+    """Clear API model state and all cached model instances."""
+    global _active_api_model_name
+    with _api_model_lock:
+        clear_model_cache()
+        _active_api_model_name = None
 
 
 def _safe_cleanup(path: Path) -> None:
@@ -305,7 +347,7 @@ async def create_transcription(
         except Exception:
             cache_hits_before = None
 
-        get_model(model_name)
+        get_api_model(model_name)
 
         try:
             from parakeet_rocm.models.parakeet import _get_cached_model  # type: ignore
@@ -513,6 +555,7 @@ async def create_transcription(
             code="validation_error",
         )
     except FileValidationError as exc:
+        logger.exception("API request rejected due to invalid file: id=%s", request_id)
         return _build_error_response(
             status_code=400,
             message=str(exc),
@@ -520,6 +563,7 @@ async def create_transcription(
             code="invalid_file",
         )
     except UnsupportedFormatError as exc:
+        logger.exception("API request rejected due to unsupported format: id=%s", request_id)
         return _build_error_response(
             status_code=400,
             message=str(exc),
@@ -527,6 +571,7 @@ async def create_transcription(
             code="unsupported_format",
         )
     except ValueError as exc:
+        logger.exception("API request rejected due to invalid input: id=%s", request_id)
         return _build_error_response(
             status_code=400,
             message=str(exc),
@@ -534,6 +579,25 @@ async def create_transcription(
             code="invalid_request",
         )
     except RuntimeError as exc:
+        try:
+            import torch
+        except (ModuleNotFoundError, ImportError):
+            torch = None
+
+        if torch is not None and isinstance(exc, torch.cuda.OutOfMemoryError):
+            logger.exception(
+                "API transcription failed due to GPU memory exhaustion: id=%s",
+                request_id,
+            )
+            clear_api_model_cache()
+            return _build_error_response(
+                status_code=503,
+                message="GPU is out of memory. Please retry after freeing GPU memory.",
+                error_type="server_error",
+                code="gpu_oom",
+            )
+
+        logger.exception("API transcription runtime failure: id=%s", request_id)
         lowered_error = str(exc).lower()
         is_audio_format_error = (
             ("ffmpeg" in lowered_error and "format" in lowered_error)
@@ -555,19 +619,6 @@ async def create_transcription(
             code="runtime_error",
         )
     except Exception as exc:
-        try:
-            import torch
-        except (ModuleNotFoundError, ImportError):
-            torch = None
-
-        if torch is not None and isinstance(exc, torch.cuda.OutOfMemoryError):
-            return _build_error_response(
-                status_code=503,
-                message="GPU is out of memory. Please retry with a smaller input.",
-                error_type="server_error",
-                code="gpu_oom",
-            )
-
         exception_module = getattr(exc.__class__, "__module__", "") or ""
         if "nemo" in exception_module.lower():
             status_code, error_type, error_code = _nemo_error_status(str(exc))

--- a/parakeet_rocm/api/routes.py
+++ b/parakeet_rocm/api/routes.py
@@ -8,8 +8,10 @@ import tempfile
 import threading
 from pathlib import Path
 from time import monotonic, perf_counter
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
+import torch
 from fastapi import APIRouter, BackgroundTasks, File, Form, Request, UploadFile
 from fastapi.responses import JSONResponse, PlainTextResponse, Response
 from pydantic import ValidationError
@@ -37,6 +39,9 @@ from parakeet_rocm.transcription import cli_transcribe
 from parakeet_rocm.utils.constant import API_DEFAULT_BATCH_SIZE, API_DEFAULT_CHUNK_LEN_SEC
 from parakeet_rocm.utils.logging_config import get_logger
 from parakeet_rocm.webui.validation.file_validator import FileValidationError, validate_audio_file
+
+if TYPE_CHECKING:
+    from nemo.collections.asr.models import ASRModel
 
 logger = get_logger(__name__)
 
@@ -92,8 +97,14 @@ def has_active_api_requests() -> bool:
         return _active_api_requests > 0
 
 
-def get_api_model(model_name: str) -> object:
+def get_api_model(model_name: str) -> ASRModel:
     """Return an API model after offloading a previously active model.
+
+    Only the active-model bookkeeping and the previous-model offload are
+    performed under ``_api_model_lock``.  The expensive ``get_model()``
+    call (which may trigger GPU device promotion) runs outside the lock
+    so concurrent requests and the idle-offload worker are not blocked
+    behind slow GPU operations.
 
     Args:
         model_name: Identifier of the model selected by the API request.
@@ -111,10 +122,9 @@ def get_api_model(model_name: str) -> object:
                 model_name,
             )
             unload_model_to_cpu(previous_model_name)
-
-        model = get_model(model_name)
         _active_api_model_name = model_name
-        return model
+
+    return get_model(model_name)
 
 
 def unload_active_api_model() -> None:
@@ -555,7 +565,7 @@ async def create_transcription(
             code="validation_error",
         )
     except FileValidationError as exc:
-        logger.exception("API request rejected due to invalid file: id=%s", request_id)
+        logger.warning("API request rejected due to invalid file: id=%s err=%s", request_id, exc)
         return _build_error_response(
             status_code=400,
             message=str(exc),
@@ -563,7 +573,11 @@ async def create_transcription(
             code="invalid_file",
         )
     except UnsupportedFormatError as exc:
-        logger.exception("API request rejected due to unsupported format: id=%s", request_id)
+        logger.warning(
+            "API request rejected due to unsupported format: id=%s err=%s",
+            request_id,
+            exc,
+        )
         return _build_error_response(
             status_code=400,
             message=str(exc),
@@ -571,7 +585,7 @@ async def create_transcription(
             code="unsupported_format",
         )
     except ValueError as exc:
-        logger.exception("API request rejected due to invalid input: id=%s", request_id)
+        logger.warning("API request rejected due to invalid input: id=%s err=%s", request_id, exc)
         return _build_error_response(
             status_code=400,
             message=str(exc),
@@ -579,12 +593,7 @@ async def create_transcription(
             code="invalid_request",
         )
     except RuntimeError as exc:
-        try:
-            import torch
-        except (ModuleNotFoundError, ImportError):
-            torch = None
-
-        if torch is not None and isinstance(exc, torch.cuda.OutOfMemoryError):
+        if isinstance(exc, torch.cuda.OutOfMemoryError):
             logger.exception(
                 "API transcription failed due to GPU memory exhaustion: id=%s",
                 request_id,

--- a/parakeet_rocm/api/routes.py
+++ b/parakeet_rocm/api/routes.py
@@ -52,6 +52,7 @@ _last_api_activity_monotonic = monotonic()
 _active_api_requests = 0
 _api_model_lock = threading.Lock()
 _active_api_model_name: str | None = None
+_api_model_generation = 0
 
 
 def mark_api_activity() -> None:
@@ -112,7 +113,7 @@ def get_api_model(model_name: str) -> ASRModel:
     Returns:
         Requested model placed on the preferred device.
     """
-    global _active_api_model_name
+    global _active_api_model_name, _api_model_generation
     with _api_model_lock:
         previous_model_name = _active_api_model_name
         if previous_model_name is not None and previous_model_name != model_name:
@@ -123,23 +124,42 @@ def get_api_model(model_name: str) -> ASRModel:
             )
             unload_model_to_cpu(previous_model_name)
         _active_api_model_name = model_name
+        generation = _api_model_generation
 
-    return get_model(model_name)
+    try:
+        return get_model(model_name)
+    except Exception:
+        with _api_model_lock:
+            if _api_model_generation == generation:
+                _active_api_model_name = previous_model_name
+        raise
 
 
 def unload_active_api_model() -> None:
-    """Offload the active API model without loading a cache miss."""
+    """Offload the active API model without loading a cache miss.
+
+    Acquires ``_api_model_lock`` and, when a model is currently active,
+    moves it to CPU via ``unload_model_to_cpu``.  The active-model name is
+    left unchanged so a subsequent ``get_api_model`` call can reuse it.
+    """
     with _api_model_lock:
         if _active_api_model_name is not None:
             unload_model_to_cpu(_active_api_model_name)
 
 
 def clear_api_model_cache() -> None:
-    """Clear API model state and all cached model instances."""
-    global _active_api_model_name
+    """Clear API model state and all cached model instances.
+
+    Acquires ``_api_model_lock``, calls ``clear_model_cache`` to drop every
+    cached ``ASRModel`` instance, resets ``_active_api_model_name`` to
+    ``None``, and bumps ``_api_model_generation`` so in-flight
+    ``get_api_model`` rollbacks do not clobber the cleared state.
+    """
+    global _active_api_model_name, _api_model_generation
     with _api_model_lock:
         clear_model_cache()
         _active_api_model_name = None
+        _api_model_generation += 1
 
 
 def _safe_cleanup(path: Path) -> None:

--- a/tests/unit/test_api_routes.py
+++ b/tests/unit/test_api_routes.py
@@ -409,6 +409,68 @@ def test_get_api_model__offloads_previous_model_before_loading_replacement(
     ]
 
 
+def test_unload_active_api_model__offloads_when_model_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """unload_active_api_model should offload the active model via unload_model_to_cpu."""
+    offload_calls: list[str] = []
+    monkeypatch.setattr(routes, "_active_api_model_name", "test-model")
+    monkeypatch.setattr(
+        routes,
+        "unload_model_to_cpu",
+        lambda name: offload_calls.append(name),
+    )
+
+    routes.unload_active_api_model()
+
+    assert offload_calls == ["test-model"]
+
+
+def test_unload_active_api_model__noop_when_no_model_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """unload_active_api_model should be a no-op when no model is active."""
+    offload_calls: list[str] = []
+    monkeypatch.setattr(routes, "_active_api_model_name", None)
+    monkeypatch.setattr(
+        routes,
+        "unload_model_to_cpu",
+        lambda name: offload_calls.append(name),
+    )
+
+    routes.unload_active_api_model()
+
+    assert offload_calls == []
+
+
+def test_clear_api_model_cache__clears_cache_and_resets_active_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """clear_api_model_cache should call clear_model_cache and reset _active_api_model_name."""
+    clear_calls: list[None] = []
+    monkeypatch.setattr(routes, "_active_api_model_name", "test-model")
+    monkeypatch.setattr(routes, "clear_model_cache", lambda: clear_calls.append(None))
+
+    routes.clear_api_model_cache()
+
+    assert clear_calls == [None]
+    assert routes._active_api_model_name is None
+
+
+def test_clear_api_model_cache__noop_when_already_clear(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """clear_api_model_cache should still call clear_model_cache even when no model is active."""
+    clear_calls: list[None] = []
+    monkeypatch.setattr(routes, "_active_api_model_name", None)
+    monkeypatch.setattr(routes, "clear_model_cache", lambda: clear_calls.append(None))
+
+    routes.clear_api_model_cache()
+
+    assert clear_calls == [None]
+    assert routes._active_api_model_name is None
+
+
 def test_create_transcription__rejects_invalid_model(
     test_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_api_routes.py
+++ b/tests/unit/test_api_routes.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
+import torch
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -328,6 +330,7 @@ def test_create_transcription__ffmpeg_format_error_returns_invalid_audio_format(
 def test_create_transcription__unrelated_format_error_returns_runtime_error(
     test_client: TestClient,
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Unrelated format runtime failures should not be misclassified as audio errors."""
 
@@ -346,6 +349,64 @@ def test_create_transcription__unrelated_format_error_returns_runtime_error(
     assert response.status_code == 500
     payload = response.json()
     assert payload["error"]["code"] == "runtime_error"
+    assert "API transcription runtime failure" in caplog.text
+    assert "Template format key missing" in caplog.text
+
+
+def test_create_transcription__gpu_oom_releases_model_cache(
+    test_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """GPU OOM failures should release cached models and return a retryable error."""
+
+    def _raise_gpu_oom(**_kwargs: object) -> list[Path]:
+        raise torch.cuda.OutOfMemoryError("HIP out of memory")
+
+    clear_cache_calls: list[None] = []
+    monkeypatch.setattr(routes, "cli_transcribe", _raise_gpu_oom)
+    monkeypatch.setattr(routes, "clear_api_model_cache", lambda: clear_cache_calls.append(None))
+
+    response = test_client.post(
+        "/v1/audio/transcriptions",
+        files={"file": ("audio.wav", b"fake-audio", "audio/wav")},
+        data={"model": "whisper-1", "response_format": "json"},
+    )
+
+    assert response.status_code == 503
+    assert response.json()["error"]["code"] == "gpu_oom"
+    assert clear_cache_calls == [None]
+    assert "GPU memory exhaustion" in caplog.text
+
+
+def test_get_api_model__offloads_previous_model_before_loading_replacement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A model change should offload the current GPU model before loading another."""
+    first_model = MagicMock()
+    replacement_model = MagicMock()
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(routes, "_active_api_model_name", None)
+    monkeypatch.setattr(
+        routes,
+        "unload_model_to_cpu",
+        lambda name: calls.append(("offload", name)),
+    )
+
+    def _get_model(name: str) -> MagicMock:
+        calls.append(("load", name))
+        return first_model if name == "first" else replacement_model
+
+    monkeypatch.setattr(routes, "get_model", _get_model)
+
+    assert routes.get_api_model("first") is first_model
+    assert routes.get_api_model("replacement") is replacement_model
+
+    assert calls == [
+        ("load", "first"),
+        ("offload", "first"),
+        ("load", "replacement"),
+    ]
 
 
 def test_create_transcription__rejects_invalid_model(

--- a/tests/unit/test_api_routes.py
+++ b/tests/unit/test_api_routes.py
@@ -409,10 +409,43 @@ def test_get_api_model__offloads_previous_model_before_loading_replacement(
     ]
 
 
+def test_get_api_model__restores_active_name_on_get_model_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """get_api_model should restore the previous active name when get_model fails.
+
+    A non-OOM ``get_model`` failure must not leave the failed model marked as
+    active.  The bookkeeping should roll back to the previous name so lifecycle
+    operations target the correct model.
+    """
+    offload_calls: list[str] = []
+    monkeypatch.setattr(routes, "_active_api_model_name", "existing")
+    monkeypatch.setattr(
+        routes,
+        "unload_model_to_cpu",
+        lambda name: offload_calls.append(name),
+    )
+
+    def _failing_get_model(_name: str) -> object:
+        raise RuntimeError("model load failed")
+
+    monkeypatch.setattr(routes, "get_model", _failing_get_model)
+
+    with pytest.raises(RuntimeError, match="model load failed"):
+        routes.get_api_model("new-model")
+
+    assert routes._active_api_model_name == "existing"
+    assert offload_calls == ["existing"]
+
+
 def test_unload_active_api_model__offloads_when_model_active(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """unload_active_api_model should offload the active model via unload_model_to_cpu."""
+    """unload_active_api_model should offload the active model via unload_model_to_cpu.
+
+    With ``_active_api_model_name`` set to a model name, the helper should
+    call ``unload_model_to_cpu`` with that name while holding the lock.
+    """
     offload_calls: list[str] = []
     monkeypatch.setattr(routes, "_active_api_model_name", "test-model")
     monkeypatch.setattr(
@@ -429,7 +462,11 @@ def test_unload_active_api_model__offloads_when_model_active(
 def test_unload_active_api_model__noop_when_no_model_active(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """unload_active_api_model should be a no-op when no model is active."""
+    """unload_active_api_model should be a no-op when no model is active.
+
+    With ``_active_api_model_name`` set to ``None``, the helper should not
+    invoke ``unload_model_to_cpu``.
+    """
     offload_calls: list[str] = []
     monkeypatch.setattr(routes, "_active_api_model_name", None)
     monkeypatch.setattr(
@@ -446,7 +483,12 @@ def test_unload_active_api_model__noop_when_no_model_active(
 def test_clear_api_model_cache__clears_cache_and_resets_active_name(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """clear_api_model_cache should call clear_model_cache and reset _active_api_model_name."""
+    """clear_api_model_cache should clear the cache and reset the active name.
+
+    With ``_active_api_model_name`` set to a model name, the helper should
+    invoke ``clear_model_cache`` and reset ``_active_api_model_name`` to
+    ``None``.
+    """
     clear_calls: list[None] = []
     monkeypatch.setattr(routes, "_active_api_model_name", "test-model")
     monkeypatch.setattr(routes, "clear_model_cache", lambda: clear_calls.append(None))
@@ -457,10 +499,14 @@ def test_clear_api_model_cache__clears_cache_and_resets_active_name(
     assert routes._active_api_model_name is None
 
 
-def test_clear_api_model_cache__noop_when_already_clear(
+def test_clear_api_model_cache__clears_when_no_model_active(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """clear_api_model_cache should still call clear_model_cache even when no model is active."""
+    """clear_api_model_cache should still clear the cache when no model is active.
+
+    With ``_active_api_model_name`` already ``None``, the helper should
+    still invoke ``clear_model_cache`` and keep the name at ``None``.
+    """
     clear_calls: list[None] = []
     monkeypatch.setattr(routes, "_active_api_model_name", None)
     monkeypatch.setattr(routes, "clear_model_cache", lambda: clear_calls.append(None))


### PR DESCRIPTION
## Summary

Fixes API model switching so the previously active model is offloaded before a requested replacement is loaded, and makes GPU out-of-memory failures observable and retryable.

Closes #44.

## Root cause

The API retained its warmed model on GPU while loading a different requested model. On constrained ROCm hardware this could exhaust VRAM; `OutOfMemoryError` was also caught by the broader `RuntimeError` handler and returned as a generic 500.

## Changes

- Track the active API model across warmup, request handling, idle offload, and cache clearing.
- Offload the active model before loading a different requested model.
- Return `503 gpu_oom` and clear the model cache after GPU OOM.
- Log handled API failures with tracebacks and add regression coverage.

## Validation

- `pdm run ruff check parakeet_rocm/api/app.py parakeet_rocm/api/routes.py tests/unit/test_api_routes.py`
- `pdm run ruff format --check parakeet_rocm/api/app.py parakeet_rocm/api/routes.py tests/unit/test_api_routes.py`
- Live container verification: warmed CTC model was offloaded, v3 loaded, and transcription completed with HTTP 200.

The full local CI wrapper was attempted but stalled in FastAPI multipart parsing before the request handler began in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model switching by unloading previously active models before loading replacements.
  * Added automatic cleanup of inactive or expired models to better manage GPU memory.
  * Improved handling of GPU out-of-memory errors, including cache cleanup and clearer error reporting.
  * Enhanced logging for invalid inputs, unsupported formats, and runtime failures.
  * Added safer recovery when model loading fails, helping maintain a stable transcription service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->