### PR TITLE
fix: restore mounted WebUI styling and app metadata

### DIFF
--- a/parakeet_rocm/api/app.py
+++ b/parakeet_rocm/api/app.py
@@ -7,7 +7,7 @@ import time
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import RedirectResponse, Response
+from fastapi.responses import FileResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 
 from parakeet_rocm.api import routes as api_routes
@@ -157,12 +157,14 @@ def create_app(*, include_ui: bool = True, ui_path: str = "/ui") -> FastAPI:
         return app
 
     from parakeet_rocm.webui.app import (
+        WEBUI_CONTAINER_CSS,
         _cleanup_models,
         _start_idle_offload_thread,
         build_app,
     )
-    from parakeet_rocm.webui.assets import WEBUI_ASSET_DIR
+    from parakeet_rocm.webui.assets import WEBUI_ASSET_DIR, WEBUI_HEAD_HTML
     from parakeet_rocm.webui.core.job_manager import JobManager
+    from parakeet_rocm.webui.ui.theme import configure_theme
 
     # Single-process architecture: both API and Gradio share the same model cache.
     job_manager = JobManager()
@@ -175,6 +177,15 @@ def create_app(*, include_ui: bool = True, ui_path: str = "/ui") -> FastAPI:
         StaticFiles(directory=WEBUI_ASSET_DIR),
         name="parakeet-assets",
     )
+
+    @app.get(f"{ui_path}/favicon.ico", include_in_schema=False)
+    async def webui_favicon() -> FileResponse:
+        """Serve the Parakeet favicon at the mounted browser-default URL.
+
+        Returns:
+            The packaged multi-size Parakeet favicon.
+        """
+        return FileResponse(WEBUI_ASSET_DIR / "favicon.ico", media_type="image/x-icon")
 
     @app.on_event("startup")
     async def _on_startup() -> None:
@@ -206,6 +217,11 @@ def create_app(*, include_ui: bool = True, ui_path: str = "/ui") -> FastAPI:
         app,
         gradio_app,
         path=ui_path or "/",
+        theme=configure_theme(),
+        css=WEBUI_CONTAINER_CSS,
+        head=WEBUI_HEAD_HTML,
+        favicon_path=(str(WEBUI_ASSET_DIR / "favicon.ico") if not ui_path else None),
+        pwa=False,
     )
 
 

--- a/parakeet_rocm/webui/__init__.py
+++ b/parakeet_rocm/webui/__init__.py
@@ -8,16 +8,15 @@ of concerns, protocol-oriented design for testability, and comprehensive
 input validation.
 
 Examples:
-    Launch the WebUI from code:
+    Launch the supported standalone WebUI composition from code:
 
     >>> from parakeet_rocm.webui import launch_app
     >>> launch_app()
 
-    Or build and customize the app:
+    Build Blocks for embedding in the FastAPI composition:
 
     >>> from parakeet_rocm.webui import build_app
-    >>> app = build_app()
-    >>> app.launch(server_name="localhost", server_port=7860)
+    >>> blocks = build_app()
 """
 
 from __future__ import annotations

--- a/parakeet_rocm/webui/app.py
+++ b/parakeet_rocm/webui/app.py
@@ -43,13 +43,11 @@ from parakeet_rocm.utils.constant import (
     SUPPORTED_EXTENSIONS,
 )
 from parakeet_rocm.utils.logging_config import configure_logging, get_logger
-from parakeet_rocm.webui.assets import WEBUI_HEAD_HTML
 from parakeet_rocm.webui.core.job_manager import JobManager, JobStatus
 from parakeet_rocm.webui.core.session import (
     SessionManager,
     set_global_job_manager,
 )
-from parakeet_rocm.webui.ui.theme import configure_theme
 from parakeet_rocm.webui.utils.metrics_formatter import (
     format_gpu_stats_section,
     format_runtime_section,
@@ -204,15 +202,11 @@ def build_app(
 
     session_manager = SessionManager()
 
-    # Build application
-    # theme/css/head live on the Blocks build boundary — the only place
-    # Gradio 5.x supports them.  ``mount_gradio_app`` and ``launch`` do not.
+    # Mount/launch options are applied at the server boundary so mounted Gradio
+    # apps receive the same styling as standalone development launches.
     with gr.Blocks(
         title="Parakeet-ROCm WebUI",
         analytics_enabled=analytics_enabled,
-        theme=configure_theme(),
-        css=WEBUI_CONTAINER_CSS,
-        head=WEBUI_HEAD_HTML,
     ) as app:
         # Session state (for future use)
         # Reserved for future session features

--- a/parakeet_rocm/webui/app.py
+++ b/parakeet_rocm/webui/app.py
@@ -43,7 +43,6 @@ from parakeet_rocm.utils.constant import (
     SUPPORTED_EXTENSIONS,
 )
 from parakeet_rocm.utils.logging_config import configure_logging, get_logger
-from parakeet_rocm.webui.assets import WEBUI_HEAD_HTML
 from parakeet_rocm.webui.core.job_manager import JobManager, JobStatus
 from parakeet_rocm.webui.core.session import (
     SessionManager,
@@ -184,11 +183,10 @@ def build_app(
         analytics_enabled: Enable Gradio analytics tracking.
 
     Returns:
-        Configured Gradio Blocks application ready to launch.
+        Configured Gradio Blocks application ready for the FastAPI composition.
 
     Examples:
         >>> app = build_app()
-        >>> app.launch()
 
         >>> # With custom job manager
         >>> manager = JobManager()
@@ -204,15 +202,14 @@ def build_app(
 
     session_manager = SessionManager()
 
-    # Keep these options on Blocks for the public ``build_app().launch()`` path.
-    # Gradio 6.5.1 resets them while mounting, so ``create_app()`` also supplies
-    # the same values explicitly to ``mount_gradio_app()``.
+    # Keep visual styling on Blocks for embedding and previews. Install metadata
+    # is supplied by ``create_app()``, where the referenced asset routes exist.
+    # ``launch_app()`` is the supported standalone server entry point.
     with gr.Blocks(
         title="Parakeet-ROCm WebUI",
         analytics_enabled=analytics_enabled,
         theme=configure_theme(),
         css=WEBUI_CONTAINER_CSS,
-        head=WEBUI_HEAD_HTML,
     ) as app:
         # Session state (for future use)
         # Reserved for future session features

--- a/parakeet_rocm/webui/app.py
+++ b/parakeet_rocm/webui/app.py
@@ -43,11 +43,13 @@ from parakeet_rocm.utils.constant import (
     SUPPORTED_EXTENSIONS,
 )
 from parakeet_rocm.utils.logging_config import configure_logging, get_logger
+from parakeet_rocm.webui.assets import WEBUI_HEAD_HTML
 from parakeet_rocm.webui.core.job_manager import JobManager, JobStatus
 from parakeet_rocm.webui.core.session import (
     SessionManager,
     set_global_job_manager,
 )
+from parakeet_rocm.webui.ui.theme import configure_theme
 from parakeet_rocm.webui.utils.metrics_formatter import (
     format_gpu_stats_section,
     format_runtime_section,
@@ -202,11 +204,15 @@ def build_app(
 
     session_manager = SessionManager()
 
-    # Mount/launch options are applied at the server boundary so mounted Gradio
-    # apps receive the same styling as standalone development launches.
+    # Keep these options on Blocks for the public ``build_app().launch()`` path.
+    # Gradio 6.5.1 resets them while mounting, so ``create_app()`` also supplies
+    # the same values explicitly to ``mount_gradio_app()``.
     with gr.Blocks(
         title="Parakeet-ROCm WebUI",
         analytics_enabled=analytics_enabled,
+        theme=configure_theme(),
+        css=WEBUI_CONTAINER_CSS,
+        head=WEBUI_HEAD_HTML,
     ) as app:
         # Session state (for future use)
         # Reserved for future session features

--- a/parakeet_rocm/webui/app.py
+++ b/parakeet_rocm/webui/app.py
@@ -63,7 +63,19 @@ from parakeet_rocm.webui.validation.file_validator import (
 # Module logger
 logger = get_logger(__name__)
 
-WEBUI_CONTAINER_CSS = ".gradio-container { max-width: 1200px; margin: auto; }"
+WEBUI_CONTAINER_CSS = """
+.gradio-container { max-width: 1200px; margin: auto; }
+.parakeet-title { display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.5rem; }
+.parakeet-title img { width: 2.5rem; height: 2.5rem; flex: 0 0 auto; }
+.parakeet-title h1 { margin: 0; }
+"""
+
+WEBUI_TITLE_HTML = """\
+<div class="parakeet-title">
+  <img src="./parakeet-assets/parakeet-rocm-icon.svg" alt="">
+  <h1>Parakeet-ROCm WebUI</h1>
+</div>
+"""
 
 
 def _require_gradio() -> None:
@@ -216,7 +228,7 @@ def build_app(
         _session_state = gr.State(session_manager.create_session())
 
         # Header
-        gr.Markdown("# 🎤 Parakeet-ROCm WebUI")
+        gr.Markdown(WEBUI_TITLE_HTML)
         gr.Markdown(
             "Upload audio or video files and transcribe them using NVIDIA's Parakeet-NEMO models."
         )

--- a/parakeet_rocm/webui/assets.py
+++ b/parakeet_rocm/webui/assets.py
@@ -8,6 +8,12 @@ WEBUI_ASSET_DIR = Path(__file__).with_name("assets")
 """Directory containing public WebUI icon assets."""
 
 WEBUI_HEAD_HTML = """\
+<title>Parakeet-ROCm WebUI</title>
+<meta name="application-name" content="Parakeet-ROCm WebUI">
+<meta name="apple-mobile-web-app-title" content="Parakeet">
+<meta name="apple-mobile-web-app-capable" content="yes">
+<meta name="mobile-web-app-capable" content="yes">
+<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
 <link rel="icon" href="./parakeet-assets/favicon.ico" sizes="any">
 <link rel="icon" type="image/png" sizes="192x192" href="./parakeet-assets/icon-192.png">
 <link rel="apple-touch-icon" sizes="180x180" href="./parakeet-assets/apple-touch-icon.png">

--- a/parakeet_rocm/webui/assets/manifest.webmanifest
+++ b/parakeet_rocm/webui/assets/manifest.webmanifest
@@ -2,6 +2,7 @@
   "name": "Parakeet-ROCm WebUI",
   "short_name": "Parakeet",
   "description": "Audio transcription with Parakeet models on AMD ROCm.",
+  "id": "../",
   "start_url": "../",
   "scope": "../",
   "display": "standalone",
@@ -12,13 +13,25 @@
       "src": "./icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
       "src": "./icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
+    },
+    {
+      "src": "./icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
+    },
+    {
+      "src": "./icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
     }
   ]
 }

--- a/tests/unit/test_api_app.py
+++ b/tests/unit/test_api_app.py
@@ -192,6 +192,9 @@ def test_create_app__serves_root_relative_webui_icons(
     root_mount_kwargs = state["mount_kwargs"]
     assert isinstance(root_mount_kwargs, dict)
     assert str(root_mount_kwargs["favicon_path"]).endswith("/favicon.ico")
+    favicon = client.get("/favicon.ico")
+    assert favicon.status_code == 200
+    assert favicon.content == client.get("/parakeet-assets/favicon.ico").content
     for asset_name in ("favicon.ico", "apple-touch-icon.png", "manifest.webmanifest"):
         response = client.get(f"/parakeet-assets/{asset_name}")
         assert response.status_code == 200

--- a/tests/unit/test_api_app.py
+++ b/tests/unit/test_api_app.py
@@ -52,6 +52,7 @@ def _install_fake_webui_modules(monkeypatch: pytest.MonkeyPatch) -> dict[str, ob
     fake_webui_app.build_app = build_app
     fake_webui_app._start_idle_offload_thread = _start_idle_offload_thread
     fake_webui_app._cleanup_models = _cleanup_models
+    fake_webui_app.WEBUI_CONTAINER_CSS = ".gradio-container { max-width: 1200px; margin: auto; }"
     monkeypatch.setitem(sys.modules, "parakeet_rocm.webui.app", fake_webui_app)
 
     fake_job_manager = types.ModuleType("parakeet_rocm.webui.core.job_manager")
@@ -82,9 +83,10 @@ def _install_fake_webui_modules(monkeypatch: pytest.MonkeyPatch) -> dict[str, ob
         _gradio_app: object,
         *,
         path: str,
+        **kwargs: object,
     ) -> FastAPI:
         state["mount_path"] = path
-        state["mount_kwargs"] = {}
+        state["mount_kwargs"] = kwargs
         gradio_routes = FastAPI()
 
         @gradio_routes.get("/assets/gradio-frontend.js")
@@ -120,6 +122,13 @@ def test_create_app_root_and_health(monkeypatch: pytest.MonkeyPatch) -> None:
     client = TestClient(app)
 
     assert state["mount_path"] == "/ui"
+    mount_kwargs = state["mount_kwargs"]
+    assert isinstance(mount_kwargs, dict)
+    assert mount_kwargs["theme"] is not None
+    assert mount_kwargs["css"] == ".gradio-container { max-width: 1200px; margin: auto; }"
+    assert "apple-mobile-web-app-title" in str(mount_kwargs["head"])
+    assert mount_kwargs["favicon_path"] is None
+    assert mount_kwargs["pwa"] is False
 
     health = client.get("/health")
     assert health.status_code == 200
@@ -180,6 +189,9 @@ def test_create_app__serves_root_relative_webui_icons(
     client = TestClient(app)
 
     assert state["mount_path"] == "/"
+    root_mount_kwargs = state["mount_kwargs"]
+    assert isinstance(root_mount_kwargs, dict)
+    assert str(root_mount_kwargs["favicon_path"]).endswith("/favicon.ico")
     for asset_name in ("favicon.ico", "apple-touch-icon.png", "manifest.webmanifest"):
         response = client.get(f"/parakeet-assets/{asset_name}")
         assert response.status_code == 200

--- a/tests/unit/test_webui_app.py
+++ b/tests/unit/test_webui_app.py
@@ -327,13 +327,13 @@ def test_webui_app_build_and_handlers(monkeypatch: pytest.MonkeyPatch, tmp_path:
     blocks = app_mod.build_app(job_manager=fake_jm, analytics_enabled=False)
     assert isinstance(blocks, _FakeBlocks)
 
-    # Direct ``build_app().launch()`` keeps the same styling and metadata as
-    # the FastAPI-mounted path.
+    # Blocks retain visual styling. Install metadata is applied only by the
+    # FastAPI composition, which owns the referenced static routes.
     assert blocks.init_kwargs["title"] == "Parakeet-ROCm WebUI"
     assert blocks.init_kwargs["analytics_enabled"] is False
     assert blocks.init_kwargs["theme"] is not None
     assert blocks.init_kwargs["css"] == app_mod.WEBUI_CONTAINER_CSS
-    assert blocks.init_kwargs["head"] == app_mod.WEBUI_HEAD_HTML
+    assert "head" not in blocks.init_kwargs
 
     # Find the registered click handlers.
     click_fns = [c._click_fn for c in gr._created if getattr(c, "_click_fn", None) is not None]

--- a/tests/unit/test_webui_app.py
+++ b/tests/unit/test_webui_app.py
@@ -327,11 +327,13 @@ def test_webui_app_build_and_handlers(monkeypatch: pytest.MonkeyPatch, tmp_path:
     blocks = app_mod.build_app(job_manager=fake_jm, analytics_enabled=False)
     assert isinstance(blocks, _FakeBlocks)
 
-    # Styling and install metadata are applied by the Gradio 6 mount contract.
-    assert blocks.init_kwargs == {
-        "title": "Parakeet-ROCm WebUI",
-        "analytics_enabled": False,
-    }
+    # Direct ``build_app().launch()`` keeps the same styling and metadata as
+    # the FastAPI-mounted path.
+    assert blocks.init_kwargs["title"] == "Parakeet-ROCm WebUI"
+    assert blocks.init_kwargs["analytics_enabled"] is False
+    assert blocks.init_kwargs["theme"] is not None
+    assert blocks.init_kwargs["css"] == app_mod.WEBUI_CONTAINER_CSS
+    assert blocks.init_kwargs["head"] == app_mod.WEBUI_HEAD_HTML
 
     # Find the registered click handlers.
     click_fns = [c._click_fn for c in gr._created if getattr(c, "_click_fn", None) is not None]

--- a/tests/unit/test_webui_app.py
+++ b/tests/unit/test_webui_app.py
@@ -327,17 +327,11 @@ def test_webui_app_build_and_handlers(monkeypatch: pytest.MonkeyPatch, tmp_path:
     blocks = app_mod.build_app(job_manager=fake_jm, analytics_enabled=False)
     assert isinstance(blocks, _FakeBlocks)
 
-    # theme/css/head are bound on the gr.Blocks build boundary, not on
-    # mount_gradio_app or launch (neither accepts them in Gradio 5.x).
-    assert blocks.init_kwargs.get("theme") is not None
-    assert "max-width" in blocks.init_kwargs.get("css", "")
-    head = str(blocks.init_kwargs["head"])
-    for asset_name in (
-        "favicon.ico",
-        "apple-touch-icon.png",
-        "manifest.webmanifest",
-    ):
-        assert f"./parakeet-assets/{asset_name}" in head
+    # Styling and install metadata are applied by the Gradio 6 mount contract.
+    assert blocks.init_kwargs == {
+        "title": "Parakeet-ROCm WebUI",
+        "analytics_enabled": False,
+    }
 
     # Find the registered click handlers.
     click_fns = [c._click_fn for c in gr._created if getattr(c, "_click_fn", None) is not None]

--- a/tests/unit/test_webui_app.py
+++ b/tests/unit/test_webui_app.py
@@ -334,6 +334,14 @@ def test_webui_app_build_and_handlers(monkeypatch: pytest.MonkeyPatch, tmp_path:
     assert blocks.init_kwargs["theme"] is not None
     assert blocks.init_kwargs["css"] == app_mod.WEBUI_CONTAINER_CSS
     assert "head" not in blocks.init_kwargs
+    markdown_values = [
+        component.args[0]
+        for component in gr._created
+        if component.args and isinstance(component.args[0], str)
+    ]
+    assert app_mod.WEBUI_TITLE_HTML in markdown_values
+    assert "./parakeet-assets/parakeet-rocm-icon.svg" in app_mod.WEBUI_TITLE_HTML
+    assert "🎤" not in app_mod.WEBUI_TITLE_HTML
 
     # Find the registered click handlers.
     click_fns = [c._click_fn for c in gr._created if getattr(c, "_click_fn", None) is not None]

--- a/tests/unit/test_webui_mount_regression.py
+++ b/tests/unit/test_webui_mount_regression.py
@@ -13,10 +13,14 @@ import pytest
 from fastapi.testclient import TestClient
 
 
-def test_mounted_webui_uses_parakeet_styling_and_install_metadata(
+def test_mounted_webui__uses_parakeet_styling_and_install_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The mounted document should use Parakeet styling, metadata, and assets."""
+    """Verify mounted styling, metadata, and assets.
+
+    Args:
+        monkeypatch: Fixture used to isolate model and WebUI modules.
+    """
     fake_models = types.ModuleType("parakeet_rocm.models.parakeet")
     setattr(fake_models, "get_model", lambda *_args, **_kwargs: object())
     monkeypatch.setitem(sys.modules, "parakeet_rocm.models.parakeet", fake_models)

--- a/tests/unit/test_webui_mount_regression.py
+++ b/tests/unit/test_webui_mount_regression.py
@@ -1,0 +1,98 @@
+"""Regression coverage for the real Gradio mounted-app contract."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import types
+from urllib.parse import urljoin
+
+import gradio as gr
+import pytest
+from fastapi.testclient import TestClient
+
+
+def test_mounted_webui_uses_parakeet_styling_and_install_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The mounted document should use Parakeet styling, metadata, and assets."""
+    fake_models = types.ModuleType("parakeet_rocm.models.parakeet")
+    setattr(fake_models, "get_model", lambda *_args, **_kwargs: object())
+    monkeypatch.setitem(sys.modules, "parakeet_rocm.models.parakeet", fake_models)
+    fake_transcription = types.ModuleType("parakeet_rocm.transcription")
+    setattr(fake_transcription, "cli_transcribe", lambda *_args, **_kwargs: None)
+    monkeypatch.setitem(sys.modules, "parakeet_rocm.transcription", fake_transcription)
+
+    fake_webui_app = types.ModuleType("parakeet_rocm.webui.app")
+
+    def build_app(**_kwargs: object) -> gr.Blocks:
+        with gr.Blocks(title="Parakeet-ROCm WebUI") as blocks:
+            gr.Markdown("# Parakeet")
+        return blocks
+
+    setattr(fake_webui_app, "build_app", build_app)
+    setattr(fake_webui_app, "_start_idle_offload_thread", lambda _manager: None)
+    setattr(fake_webui_app, "_cleanup_models", lambda: None)
+    setattr(
+        fake_webui_app,
+        "WEBUI_CONTAINER_CSS",
+        ".gradio-container { max-width: 1200px; margin: auto; }",
+    )
+    monkeypatch.setitem(sys.modules, "parakeet_rocm.webui.app", fake_webui_app)
+    fake_job_manager = types.ModuleType("parakeet_rocm.webui.core.job_manager")
+    setattr(fake_job_manager, "JobManager", type("JobManager", (), {}))
+    monkeypatch.setitem(sys.modules, "parakeet_rocm.webui.core.job_manager", fake_job_manager)
+    monkeypatch.delitem(sys.modules, "parakeet_rocm.webui.ui.theme", raising=False)
+
+    from parakeet_rocm.api import app as api_app
+
+    monkeypatch.setattr(api_app, "API_ENABLED", False)
+    monkeypatch.setattr(api_app, "API_CORS_ORIGINS", "")
+    monkeypatch.setattr(api_app, "API_MODEL_WARMUP_ON_START", False)
+
+    client = TestClient(api_app.create_app())
+    config = client.get("/ui/config").json()
+    assert config["css"] == ".gradio-container { max-width: 1200px; margin: auto; }"
+    assert config["theme_hash"]
+    assert config["title"] == "Parakeet-ROCm WebUI"
+    assert "<title>Parakeet-ROCm WebUI</title>" in config["head"]
+
+    document = client.get("/ui/").text
+    for marker in (
+        "application-name",
+        "apple-mobile-web-app-title",
+        "apple-mobile-web-app-capable",
+        "mobile-web-app-capable",
+        "apple-touch-icon",
+        "./parakeet-assets/manifest.webmanifest",
+        "./parakeet-assets/favicon.ico",
+        "theme-color",
+    ):
+        assert marker in document
+    assert document.count("manifest.webmanifest") == 1
+    assert "/assets/logo.svg" not in document
+
+    for asset_name in (
+        "favicon.ico",
+        "icon-192.png",
+        "icon-512.png",
+        "apple-touch-icon.png",
+        "manifest.webmanifest",
+    ):
+        assert client.get(f"/ui/parakeet-assets/{asset_name}").status_code == 200
+    favicon = client.get("/ui/favicon.ico")
+    assert favicon.content == client.get("/ui/parakeet-assets/favicon.ico").content
+
+    manifest = json.loads(client.get("/ui/parakeet-assets/manifest.webmanifest").text)
+    base = "http://testserver/ui/parakeet-assets/manifest.webmanifest"
+    assert manifest["name"] == "Parakeet-ROCm WebUI"
+    assert manifest["short_name"] == "Parakeet"
+    for key in ("id", "start_url", "scope"):
+        assert urljoin(base, manifest[key]) == "http://testserver/ui/"
+    assert {icon["purpose"] for icon in manifest["icons"]} == {"any", "maskable"}
+
+    frontend_asset_path = re.search(r'src="(\./assets/[^"]+\.js)"', document)
+    assert frontend_asset_path is not None
+    frontend_asset = client.get(urljoin("http://testserver/ui/", frontend_asset_path.group(1)))
+    assert frontend_asset.status_code == 200


### PR DESCRIPTION
## Summary

- Restores the custom Gradio theme and container CSS at the Gradio 6.5.1 mount boundary.
- Connects the packaged Parakeet favicon, Apple touch icon, application naming, and PWA manifest to the mounted `/ui/` document.
- Adds a real mounted-app regression test against Gradio 6.5.1 instead of relying only on fake mount contracts.

## Root cause

PR #47 moved `theme`, `css`, and `head` to `gr.Blocks(...)` based on an incorrect Gradio 5.39 assumption. The locked and deployed Gradio 6.5.1 mount resets those values unless they are supplied to `mount_gradio_app()`. The live app therefore had `css=""`, `head=""`, the default Gradio theme, Gradio favicon, and ineffective install metadata.

## Validation

- `15 passed` in the focused API/WebUI suite using the lightweight Gradio 6.5.1 environment.
- Ruff check passed.
- Ruff format check passed.
- Wheel build succeeded and contains all packaged WebUI assets.
- Ephemeral mounted-app probe returned HTTP 200 for the UI and assets; `/ui/config` contained non-empty CSS/head/theme data and the document contained Parakeet/Apple/manifest metadata.

## Safety

- Draft hotfix only.
- No deployment, SSH, service restart, GPU model load, Torch, or ROCm action performed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent Parakeet branding, themes, page titles, custom CSS, and a branded header.
  - Added favicon support for interfaces mounted at `/ui` or the site root.
  - Added mobile and installable-app metadata for improved progressive web app compatibility.
  - Updated web app icons and manifest settings for better browser and device support.

- **Bug Fixes**
  - Improved asset and metadata handling when mounting the web interface at different paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->