### PR TITLE
fix 🐛: Repair dev regression tests

### DIFF
--- a/tests/integration/test_api_integration.py
+++ b/tests/integration/test_api_integration.py
@@ -17,6 +17,8 @@ def _stub_model_module(monkeypatch: pytest.MonkeyPatch) -> None:
     """Avoid importing optional NeMo dependencies in API integration tests."""
     fake_models = types.ModuleType("parakeet_rocm.models.parakeet")
     fake_models.get_model = lambda *_args, **_kwargs: object()
+    fake_models.clear_model_cache = lambda: None
+    fake_models.unload_model_to_cpu = lambda: None
     monkeypatch.setitem(sys.modules, "parakeet_rocm.models.parakeet", fake_models)
     fake_transcription = types.ModuleType("parakeet_rocm.transcription")
     fake_transcription.cli_transcribe = lambda *_args, **_kwargs: None
@@ -44,6 +46,7 @@ def _install_fake_webui_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
     fake_webui_app.build_app = build_app
     fake_webui_app._start_idle_offload_thread = _start_idle_offload_thread
     fake_webui_app._cleanup_models = _cleanup_models
+    fake_webui_app.WEBUI_CONTAINER_CSS = ".gradio-container {}"
     monkeypatch.setitem(sys.modules, "parakeet_rocm.webui.app", fake_webui_app)
 
     fake_job_manager = types.ModuleType("parakeet_rocm.webui.core.job_manager")
@@ -74,6 +77,7 @@ def _install_fake_webui_runtime(monkeypatch: pytest.MonkeyPatch) -> None:
         _gradio_app: object,
         *,
         path: str,
+        **_kwargs: object,
     ) -> FastAPI:
         assert path == "/ui"
         return app

--- a/tests/integration/test_file_processor.py
+++ b/tests/integration/test_file_processor.py
@@ -58,9 +58,9 @@ class TestLoadAndPrepareAudio:
 
     @patch("parakeet_rocm.transcription.file_processor.load_audio")
     @patch("parakeet_rocm.transcription.file_processor.segment_waveform")
-    @patch("typer.echo")
+    @patch("parakeet_rocm.transcription.file_processor.print_status")
     def test_load_and_prepare_audio_verbose(
-        self, mock_echo: Mock, mock_segment: Mock, mock_load: Mock
+        self, mock_print_status: Mock, mock_segment: Mock, mock_load: Mock
     ) -> None:
         """Test verbose logging during audio loading."""
         # Arrange
@@ -78,10 +78,10 @@ class TestLoadAndPrepareAudio:
             quiet=False,
         )
 
-        # Assert - verbose should trigger echo calls
-        assert mock_echo.call_count >= 1
+        # Assert - verbose should trigger Rich-backed status output.
+        assert mock_print_status.call_count >= 1
         # Check that file info was logged
-        call_args = str(mock_echo.call_args_list)
+        call_args = str(mock_print_status.call_args_list)
         assert "audio.wav" in call_args
 
 


### PR DESCRIPTION
# fix 🐛: Repair dev regression tests

## Summary

Updates two stale test doubles after the mounted-WebUI and Rich-console changes, restoring the local CI test suite.

## Why

- The mounted UI factory now imports styling and passes mount options that the integration fake did not provide.
- Verbose file-processing diagnostics now use the shared Rich status helper rather than `typer.echo`.

## Notable changes (reviewer focus)

- Expands the fake WebUI runtime to match the current API factory import and mount contract.
- Mocks `print_status` in the verbose audio-preparation test.

## Files changed

- **Counts:** 2 files changed (0 added, 2 modified, 0 deleted).
- **Key touchpoints:** API integration test fakes; file-processor verbose-output test.

<details>
<summary>File lists (auto)</summary>

### Added
- None

### Modified
- `tests/integration/test_api_integration.py`
- `tests/integration/test_file_processor.py`

### Deleted
- None
</details>

## Test plan

- [x] Unit: N/A.
- [x] Integration: Both previously failing tests pass using the existing project virtual environment.
- [x] Manual: Confirmed Ruff check and format check pass for both files.

## Risks & rollback

- **Risks:** Low; test-only changes.
- **Rollback:** Revert commit `6fd8894`.

## Additional notes

- The source checkout remains untouched; this was prepared in an isolated worktree.