### PR TITLE
fix 🐛: Complete Rich CLI validation output

### DIFF
--- a/parakeet_rocm/transcription/cli.py
+++ b/parakeet_rocm/transcription/cli.py
@@ -256,8 +256,7 @@ def cli_transcribe(
         # Show effective configuration resolved via utils.constant
         print_status(
             "env",
-            f"NEMO_LOG_LEVEL={NEMO_LOG_LEVEL}, "
-            f"TRANSFORMERS_VERBOSITY={TRANSFORMERS_VERBOSITY}",
+            f"NEMO_LOG_LEVEL={NEMO_LOG_LEVEL}, TRANSFORMERS_VERBOSITY={TRANSFORMERS_VERBOSITY}",
             quiet=quiet,
         )
         print_status(
@@ -314,12 +313,13 @@ def cli_transcribe(
     )
     if validation_errors:
         for path, msg in validation_errors:
-            typer.echo(f"Error: {path}: {msg}", err=True)
+            print_error(f"{path}: {msg}", quiet=quiet)
         if not allow_unsafe_filenames:
-            typer.echo(
-                "Hint: use --allow-unsafe-filenames to allow spaces and "
-                "special characters in filenames.",
+            print_status(
+                "hint",
+                "Use --allow-unsafe-filenames to allow spaces and special characters in filenames.",
                 err=True,
+                quiet=quiet,
             )
         raise typer.Exit(code=1)
 

--- a/tests/unit/test_transcription_cli.py
+++ b/tests/unit/test_transcription_cli.py
@@ -6,6 +6,7 @@ import runpy
 import sys
 import types
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 import typer
@@ -231,6 +232,32 @@ class TestFilenameValidationFailFast:
             )
 
         assert not model_loaded["called"], "get_model was called despite invalid filename"
+
+    def test_cli_transcribe__invalid_filename_uses_rich_error_and_hint(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Invalid filenames should use the shared styled output helpers."""
+        bad = tmp_path / "bad file.wav"
+        print_error = Mock()
+        print_status = Mock()
+        monkeypatch.setattr(transcription_cli, "print_error", print_error)
+        monkeypatch.setattr(transcription_cli, "print_status", print_status)
+
+        with pytest.raises(typer.Exit):
+            transcription_cli.cli_transcribe(
+                audio_files=[bad],
+                output_dir=tmp_path,
+                output_format="txt",
+                no_progress=True,
+            )
+
+        assert "bad file.wav" in print_error.call_args.args[0]
+        assert print_error.call_args.kwargs == {"quiet": False}
+        assert print_status.call_args.args == (
+            "hint",
+            "Use --allow-unsafe-filenames to allow spaces and special characters in filenames.",
+        )
+        assert print_status.call_args.kwargs == {"err": True, "quiet": False}
 
     def test_cli_transcribe__invalid_template_placeholder_exits_before_model_load(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path


### PR DESCRIPTION
# fix 🐛: Complete Rich CLI validation output

## Summary

Replaces the remaining plain validation error and hint output in the transcription CLI with the shared Rich helpers.

## Why

- Completes issue #39’s CLI-facing output migration.
- Keeps validation failures consistent with quiet mode and stderr routing.

## Notable changes (reviewer focus)

- Validation failures now use `print_error(..., quiet=quiet)`.
- The unsafe-filename hint is emitted as a Rich status to stderr.
- Adds a focused unit test for both helper calls.

## Files changed

- **Counts:** 2 files changed (0 added, 2 modified, 0 deleted).
- **Key touchpoints:** transcription CLI validation output; transcription CLI tests.

<details>
<summary>File lists (auto)</summary>

### Added
- None

### Modified
- `parakeet_rocm/transcription/cli.py`
- `tests/unit/test_transcription_cli.py`

### Deleted
- None
</details>

## Test plan

- [x] Unit: `pytest tests/unit/test_transcription_cli.py -q` — 10 passed.
- [x] Integration: N/A.
- [x] Manual: Confirmed no `typer.echo` remains in CLI-facing paths covered by #39.

## Risks & rollback

- **Risks:** Validation errors now honor `--quiet`, as required by the shared console contract.
- **Rollback:** Revert commit `52fa3d8`.

## Additional notes

- Closes #39.