### PR TITLE
fix 🐛: Release watch/WebUI idle model VRAM and retry failed cleanup (#50)

### DIFF
--- a/parakeet_rocm/cli.py
+++ b/parakeet_rocm/cli.py
@@ -210,6 +210,7 @@ def _setup_watch_mode(
         output_format=output_format,
         output_template=output_template,
         watch_base_dirs=base_dirs,
+        model_name=model_name,
         verbose=verbose,
         quiet=quiet,
     )

--- a/parakeet_rocm/models/parakeet.py
+++ b/parakeet_rocm/models/parakeet.py
@@ -17,6 +17,7 @@ idle-offload threads and ``clear_model_cache``.
 
 from __future__ import annotations
 
+import gc
 import threading
 from functools import lru_cache
 
@@ -199,11 +200,19 @@ def unload_model_to_cpu(model_name: str = PARAKEET_MODEL_NAME) -> None:
                 logger.debug("torch.cuda.empty_cache() failed", exc_info=True)
 
 
-def clear_model_cache() -> None:
+def clear_model_cache(release_allocator: bool = True) -> None:
     """Clear the internal LRU cache of loaded model instances.
 
     After this call, cached models are discarded and will be recreated when
     next requested.
+
+    Parameters:
+        release_allocator (bool): When ``True`` (default), also run a garbage
+            collection pass and release PyTorch's CUDA/ROCm caching-allocator
+            memory after the cached references are dropped. This reclaims
+            allocator blocks that outlive the discarded model objects, so
+            VRAM is actually returned instead of remaining parked in the
+            allocator's free pool.
     """
     with _cache_lock:
         try:
@@ -211,3 +220,26 @@ def clear_model_cache() -> None:
             _cached_keys.clear()
         except Exception:
             logger.debug("cache_clear() failed", exc_info=True)
+            return
+    if release_allocator:
+        _release_gpu_allocator_memory()
+
+
+def _release_gpu_allocator_memory() -> None:
+    """Release PyTorch CUDA/ROCm allocator memory held by freed blocks.
+
+    Best-effort: every step is guarded, so a failure never propagates to the
+    idle-cleanup caller. Garbage collection runs first so tensor objects
+    whose only reference was the cleared LRU cache become collectable before
+    the allocator release; ``torch.cuda.empty_cache()`` then returns the
+    freed blocks to the driver.
+    """
+    try:
+        gc.collect()
+    except Exception:
+        logger.debug("gc.collect() failed", exc_info=True)
+    if torch.cuda.is_available():
+        try:
+            torch.cuda.empty_cache()
+        except Exception:
+            logger.debug("torch.cuda.empty_cache() failed", exc_info=True)

--- a/parakeet_rocm/models/parakeet.py
+++ b/parakeet_rocm/models/parakeet.py
@@ -200,19 +200,25 @@ def unload_model_to_cpu(model_name: str = PARAKEET_MODEL_NAME) -> None:
                 logger.debug("torch.cuda.empty_cache() failed", exc_info=True)
 
 
-def clear_model_cache(release_allocator: bool = True) -> None:
+def clear_model_cache(release_allocator: bool = True) -> bool:
     """Clear the internal LRU cache of loaded model instances.
 
     After this call, cached models are discarded and will be recreated when
     next requested.
 
-    Parameters:
-        release_allocator (bool): When ``True`` (default), also run a garbage
+    Args:
+        release_allocator: When ``True`` (default), also run a garbage
             collection pass and release PyTorch's CUDA/ROCm caching-allocator
             memory after the cached references are dropped. This reclaims
             allocator blocks that outlive the discarded model objects, so
             VRAM is actually returned instead of remaining parked in the
             allocator's free pool.
+
+    Returns:
+        ``True`` when the cached entries were evicted; ``False`` when the
+        eviction itself failed, so idle-cleanup callers know not to mark the
+        cleanup complete and to retry on the next poll. Allocator release
+        after eviction is best-effort and never fails the call.
     """
     with _cache_lock:
         try:
@@ -220,9 +226,10 @@ def clear_model_cache(release_allocator: bool = True) -> None:
             _cached_keys.clear()
         except Exception:
             logger.debug("cache_clear() failed", exc_info=True)
-            return
+            return False
     if release_allocator:
         _release_gpu_allocator_memory()
+    return True
 
 
 def _release_gpu_allocator_memory() -> None:

--- a/parakeet_rocm/utils/watch.py
+++ b/parakeet_rocm/utils/watch.py
@@ -290,25 +290,30 @@ def watch_and_transcribe(
                         unloaded = True
                 # If still idle past clear timeout, drop the cache entirely
                 if not cleared and (now - last_activity) >= IDLE_CLEAR_TIMEOUT_SEC:
+                    if verbose:
+                        print_status(
+                            "watch",
+                            f"Idle for >= {IDLE_CLEAR_TIMEOUT_SEC}s - clearing model cache",
+                            quiet=quiet,
+                        )
+                    # clear_model_cache() reports eviction failure by
+                    # returning False instead of raising; a failed clear
+                    # leaves ``cleared`` unset and the next idle poll retries.
+                    # The except below is a belt-and-braces guard for
+                    # unexpected errors (e.g. a future re-raise variant).
                     try:
-                        if verbose:
-                            print_status(
-                                "watch",
-                                f"Idle for >= {IDLE_CLEAR_TIMEOUT_SEC}s - clearing model cache",
-                                quiet=quiet,
-                            )
-                        clear_model_cache()
+                        cleared = clear_model_cache()
                     except Exception:
                         # Never let idle cleanup crash the watcher; retry on
                         # the next idle poll instead of marking it done.
+                        cleared = False
+                    if not cleared:
                         print_status(
                             "watch",
                             "Failed to clear model cache - will retry",
                             quiet=quiet,
                             err=True,
                         )
-                    else:
-                        cleared = True
             time.sleep(poll_interval)
     finally:
         # Restore the previous SIGINT handler so the caller's signal

--- a/parakeet_rocm/utils/watch.py
+++ b/parakeet_rocm/utils/watch.py
@@ -36,6 +36,7 @@ from parakeet_rocm.utils.console import get_console, print_status
 from parakeet_rocm.utils.constant import (
     IDLE_CLEAR_TIMEOUT_SEC,
     IDLE_UNLOAD_TIMEOUT_SEC,
+    PARAKEET_MODEL_NAME,
 )
 from parakeet_rocm.utils.file_utils import (
     AUDIO_EXTENSIONS,
@@ -155,6 +156,7 @@ def watch_and_transcribe(
     output_template: str,
     watch_base_dirs: Sequence[Path] | None = None,
     audio_exts: Sequence[str] | None = None,
+    model_name: str | None = None,
     verbose: bool = False,
     quiet: bool = False,
 ) -> None:
@@ -183,11 +185,17 @@ def watch_and_transcribe(
             computing target output locations.
         audio_exts (Sequence[str] | None): Allowed audio extensions; defaults
             to ``AUDIO_EXTENSIONS`` when ``None``.
+        model_name (str | None): Name of the model the watcher should
+            offload during idle cleanup. Should match the model selected by
+            the CLI (``--model``) so idle cleanup frees the model that is
+            actually cached, not the configured default. When ``None``, the
+            ``PARAKEET_MODEL_NAME`` default is used.
         verbose: Whether to print watcher debug information.
         quiet: Whether to suppress watcher status output.
 
     """
     patterns = list(patterns)
+    watch_model_name = model_name or PARAKEET_MODEL_NAME
     print_status(
         "watch",
         f"Monitoring {escape(', '.join(map(str, patterns)))} …  (Press Ctrl+C to stop)",
@@ -268,8 +276,17 @@ def watch_and_transcribe(
                                 f"Idle for >= {IDLE_UNLOAD_TIMEOUT_SEC}s - offloading model to CPU",
                                 quiet=quiet,
                             )
-                        unload_model_to_cpu()
-                    finally:
+                        unload_model_to_cpu(watch_model_name)
+                    except Exception:
+                        # Never let idle cleanup crash the watcher; retry on
+                        # the next idle poll instead of marking it done.
+                        print_status(
+                            "watch",
+                            f"Failed to offload {watch_model_name} to CPU - will retry",
+                            quiet=quiet,
+                            err=True,
+                        )
+                    else:
                         unloaded = True
                 # If still idle past clear timeout, drop the cache entirely
                 if not cleared and (now - last_activity) >= IDLE_CLEAR_TIMEOUT_SEC:
@@ -281,7 +298,16 @@ def watch_and_transcribe(
                                 quiet=quiet,
                             )
                         clear_model_cache()
-                    finally:
+                    except Exception:
+                        # Never let idle cleanup crash the watcher; retry on
+                        # the next idle poll instead of marking it done.
+                        print_status(
+                            "watch",
+                            "Failed to clear model cache - will retry",
+                            quiet=quiet,
+                            err=True,
+                        )
+                    else:
                         cleared = True
             time.sleep(poll_interval)
     finally:

--- a/parakeet_rocm/webui/app.py
+++ b/parakeet_rocm/webui/app.py
@@ -7,7 +7,6 @@ architecture with dependency injection for testability.
 from __future__ import annotations
 
 import atexit
-import gc
 import json
 import os
 import pathlib
@@ -23,7 +22,6 @@ except ImportError:  # pragma: no cover - optional dependency
 # Pre-import scipy.linalg to avoid Cython fused_type errors when NeMo imports it later
 # via lightning.pytorch -> torchmetrics -> scipy.signal -> scipy.linalg
 import scipy.linalg  # noqa: F401
-import torch
 
 from parakeet_rocm.models.parakeet import clear_model_cache, unload_model_to_cpu
 from parakeet_rocm.utils.console import get_error_console, print_status
@@ -98,18 +96,12 @@ def _cleanup_models() -> None:
     try:
         unload_model_to_cpu()
     finally:
+        # clear_model_cache() already releases the PyTorch allocator
+        # (gc + empty_cache) internally; no extra release needed here.
         try:
             clear_model_cache()
-        finally:
-            try:
-                if torch.cuda.is_available():
-                    torch.cuda.empty_cache()
-            except Exception:
-                pass
-            try:
-                gc.collect()
-            except Exception:
-                pass
+        except Exception:
+            pass
 
 
 def _register_shutdown_handlers() -> None:
@@ -162,17 +154,23 @@ def _start_idle_offload_thread(job_manager: JobManager) -> None:
                             logger.info("[webui] Idle threshold reached - offloading model to CPU")
                             unload_model_to_cpu()
                         except Exception as e:
+                            # Never let idle cleanup crash the thread; retry on
+                            # the next idle poll instead of marking it done.
                             logger.warning(f"[webui] Failed to unload model: {e}")
-                        finally:
+                        else:
                             unloaded = True
                     if not cleared and (now - last_activity) >= IDLE_CLEAR_TIMEOUT_SEC:
+                        logger.info("[webui] Extended idle - clearing model cache")
+                        # clear_model_cache() reports eviction failure by
+                        # returning False instead of raising; a failed clear
+                        # leaves ``cleared`` unset and the next idle poll retries.
                         try:
-                            logger.info("[webui] Extended idle - clearing model cache")
-                            clear_model_cache()
+                            cleared = clear_model_cache()
                         except Exception as e:
                             logger.warning(f"[webui] Failed to clear model cache: {e}")
-                        finally:
-                            cleared = True
+                            cleared = False
+                        if not cleared:
+                            logger.warning("[webui] Failed to clear model cache - will retry")
             except Exception as e:
                 logger.warning(f"[webui] Idle offload thread error: {e}")
             time.sleep(5.0)

--- a/tests/integration/test_api_integration.py
+++ b/tests/integration/test_api_integration.py
@@ -17,7 +17,7 @@ def _stub_model_module(monkeypatch: pytest.MonkeyPatch) -> None:
     """Avoid importing optional NeMo dependencies in API integration tests."""
     fake_models = types.ModuleType("parakeet_rocm.models.parakeet")
     fake_models.get_model = lambda *_args, **_kwargs: object()
-    fake_models.clear_model_cache = lambda: None
+    fake_models.clear_model_cache = lambda: True
     fake_models.unload_model_to_cpu = lambda: None
     monkeypatch.setitem(sys.modules, "parakeet_rocm.models.parakeet", fake_models)
     fake_transcription = types.ModuleType("parakeet_rocm.transcription")

--- a/tests/unit/test_cli_unit.py
+++ b/tests/unit/test_cli_unit.py
@@ -135,7 +135,7 @@ def test_api_command_starts_api_only_app(monkeypatch: pytest.MonkeyPatch) -> Non
     assert called["share"] is False
 
 
-def test_watch_mode_forwards_cli_selected_model(
+def test_transcribe__forwards_selected_model_in_watch_mode(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """--watch mode must forward the CLI-selected model to the watcher.

--- a/tests/unit/test_cli_unit.py
+++ b/tests/unit/test_cli_unit.py
@@ -133,3 +133,48 @@ def test_api_command_starts_api_only_app(monkeypatch: pytest.MonkeyPatch) -> Non
     assert called["server_port"] == 9000
     assert called["debug"] is True
     assert called["share"] is False
+
+
+def test_watch_mode_forwards_cli_selected_model(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """--watch mode must forward the CLI-selected model to the watcher.
+
+    Regression test for issue #50: when ``--model`` differs from the
+    configured default, the watcher's idle cleanup must target the cached
+    CLI model, so the model name has to reach ``watch_and_transcribe``.
+    """
+    import importlib
+
+    received: dict[str, object] = {}
+
+    class FakeWatchModule:
+        @staticmethod
+        def watch_and_transcribe(**kwargs: object) -> list[Path]:
+            received.update(kwargs)
+            return []
+
+    class FakeTransModule:
+        @staticmethod
+        def cli_transcribe(**_kwargs: object) -> list[Path]:
+            return []
+
+    def fake_import_module(name: str) -> object:
+        if name.endswith("utils.watch"):
+            return FakeWatchModule
+        if name.endswith("transcribe"):
+            return FakeTransModule
+        raise ImportError(name)
+
+    monkeypatch.setattr(importlib, "import_module", fake_import_module)
+    monkeypatch.setattr(cli, "RESOLVE_INPUT_PATHS", lambda files: [])
+
+    cli.transcribe(
+        audio_files=None,
+        watch=[str(tmp_path)],
+        model_name="custom/model-x",
+        output_dir=tmp_path,
+        output_format="txt",
+    )
+
+    assert received.get("model_name") == "custom/model-x"

--- a/tests/unit/test_file_processor_merge.py
+++ b/tests/unit/test_file_processor_merge.py
@@ -42,6 +42,14 @@ def test_merge_word_segments_updates_segments(monkeypatch: pytest.MonkeyPatch) -
         word_segments=initial_words,
     )
 
+    # Pin the segmentation constants this test depends on: they are read from
+    # the environment at import time, so an ambient `.env` (e.g.
+    # MIN_SEGMENT_DURATION_SEC=1.5) would otherwise change the expected timing.
+    import parakeet_rocm.timestamps.segmentation as segmentation_mod
+
+    monkeypatch.setattr(segmentation_mod, "MIN_SEGMENT_DURATION_SEC", 0.5)
+    monkeypatch.setattr(segmentation_mod, "DISPLAY_BUFFER_SEC", 0.2)
+
     # Patch helpers used by _merge_word_segments
     monkeypatch.setattr(fp, "calc_time_stride", lambda _m, verbose=False: 1.0)
 

--- a/tests/unit/test_models_parakeet.py
+++ b/tests/unit/test_models_parakeet.py
@@ -111,12 +111,23 @@ def test_unload_model_to_cpu_no_gpu() -> None:
         mock_model.to.assert_called_with("cpu")
 
 
-def test_clear_model_cache_exception() -> None:
-    """Tests exception handling in clear_model_cache."""
+def test_clear_model_cache__returns_false_when_eviction_fails() -> None:
+    """Cache eviction failure is reported as False, not swallowed silently."""
     mock_fn = MagicMock()
     mock_fn.cache_clear.side_effect = RuntimeError("fail")
     with patch("parakeet_rocm.models.parakeet._get_cached_model", mock_fn):
-        clear_model_cache()
+        assert clear_model_cache() is False
+
+
+def test_clear_model_cache__returns_true_on_success() -> None:
+    """Successful eviction (with best-effort allocator release) returns True."""
+    mock_fn = MagicMock()
+    with (
+        patch("parakeet_rocm.models.parakeet._get_cached_model", mock_fn),
+        patch("parakeet_rocm.models.parakeet._release_gpu_allocator_memory"),
+    ):
+        assert clear_model_cache() is True
+    mock_fn.cache_clear.assert_called_once()
 
 
 @patch("parakeet_rocm.models.parakeet._load_model")
@@ -326,7 +337,7 @@ def test_peek_cached_model_real_path(mock_load: MagicMock) -> None:
     assert "test_model_peek" not in _cached_keys
 
 
-def test_clear_model_cache_releases_gpu_allocator() -> None:
+def test_clear_model_cache__releases_gpu_allocator() -> None:
     """Clearing the cache must also release the CUDA/ROCm allocator.
 
     Regression test: ``clear_model_cache()`` used to evict the LRU
@@ -347,7 +358,7 @@ def test_clear_model_cache_releases_gpu_allocator() -> None:
     mock_empty.assert_called_once()
 
 
-def test_clear_model_cache_gc_only_when_no_gpu() -> None:
+def test_clear_model_cache__gc_only_when_no_gpu() -> None:
     """Without CUDA available the release degrades to a GC-only pass."""
     mock_fn = MagicMock()
     with (
@@ -361,7 +372,7 @@ def test_clear_model_cache_gc_only_when_no_gpu() -> None:
     mock_empty.assert_not_called()
 
 
-def test_clear_model_cache_allocator_errors_swallowed() -> None:
+def test_clear_model_cache__allocator_errors_swallowed() -> None:
     """gc/empty_cache failures never propagate to the idle-cleanup caller."""
     mock_fn = MagicMock()
     with (
@@ -374,7 +385,7 @@ def test_clear_model_cache_allocator_errors_swallowed() -> None:
     mock_fn.cache_clear.assert_called_once()
 
 
-def test_clear_model_cache_skips_release_when_cache_clear_fails() -> None:
+def test_clear_model_cache__skips_release_when_cache_clear_fails() -> None:
     """When the LRU eviction itself fails, no allocator release is attempted."""
     mock_fn = MagicMock()
     mock_fn.cache_clear.side_effect = RuntimeError("fail")
@@ -382,11 +393,12 @@ def test_clear_model_cache_skips_release_when_cache_clear_fails() -> None:
         patch("parakeet_rocm.models.parakeet._get_cached_model", mock_fn),
         patch("parakeet_rocm.models.parakeet._release_gpu_allocator_memory") as mock_release,
     ):
-        clear_model_cache()
+        result = clear_model_cache()
+    assert result is False
     mock_release.assert_not_called()
 
 
-def test_clear_model_cache_release_allocator_flag() -> None:
+def test_clear_model_cache__release_allocator_flag() -> None:
     """release_allocator=False keeps the pure LRU-eviction behavior."""
     mock_fn = MagicMock()
     with (

--- a/tests/unit/test_models_parakeet.py
+++ b/tests/unit/test_models_parakeet.py
@@ -324,3 +324,75 @@ def test_peek_cached_model_real_path(mock_load: MagicMock) -> None:
     clear_model_cache()
     assert _peek_cached_model("test_model_peek") is None
     assert "test_model_peek" not in _cached_keys
+
+
+def test_clear_model_cache_releases_gpu_allocator() -> None:
+    """Clearing the cache must also release the CUDA/ROCm allocator.
+
+    Regression test: ``clear_model_cache()`` used to evict the LRU
+    references without a GC pass or ``torch.cuda.empty_cache()``, so VRAM
+    stayed parked in PyTorch's caching allocator even after the "cache
+    clear".
+    """
+    mock_fn = MagicMock()
+    with (
+        patch("parakeet_rocm.models.parakeet._get_cached_model", mock_fn),
+        patch("torch.cuda.is_available", return_value=True),
+        patch("torch.cuda.empty_cache") as mock_empty,
+        patch("gc.collect") as mock_gc,
+    ):
+        clear_model_cache()
+    mock_fn.cache_clear.assert_called_once()
+    mock_gc.assert_called_once()
+    mock_empty.assert_called_once()
+
+
+def test_clear_model_cache_gc_only_when_no_gpu() -> None:
+    """Without CUDA available the release degrades to a GC-only pass."""
+    mock_fn = MagicMock()
+    with (
+        patch("parakeet_rocm.models.parakeet._get_cached_model", mock_fn),
+        patch("torch.cuda.is_available", return_value=False),
+        patch("torch.cuda.empty_cache") as mock_empty,
+        patch("gc.collect") as mock_gc,
+    ):
+        clear_model_cache()
+    mock_gc.assert_called_once()
+    mock_empty.assert_not_called()
+
+
+def test_clear_model_cache_allocator_errors_swallowed() -> None:
+    """gc/empty_cache failures never propagate to the idle-cleanup caller."""
+    mock_fn = MagicMock()
+    with (
+        patch("parakeet_rocm.models.parakeet._get_cached_model", mock_fn),
+        patch("torch.cuda.is_available", return_value=True),
+        patch("torch.cuda.empty_cache", side_effect=RuntimeError("cuda gone")),
+        patch("gc.collect", side_effect=RuntimeError("gc gone")),
+    ):
+        clear_model_cache()  # must not raise
+    mock_fn.cache_clear.assert_called_once()
+
+
+def test_clear_model_cache_skips_release_when_cache_clear_fails() -> None:
+    """When the LRU eviction itself fails, no allocator release is attempted."""
+    mock_fn = MagicMock()
+    mock_fn.cache_clear.side_effect = RuntimeError("fail")
+    with (
+        patch("parakeet_rocm.models.parakeet._get_cached_model", mock_fn),
+        patch("parakeet_rocm.models.parakeet._release_gpu_allocator_memory") as mock_release,
+    ):
+        clear_model_cache()
+    mock_release.assert_not_called()
+
+
+def test_clear_model_cache_release_allocator_flag() -> None:
+    """release_allocator=False keeps the pure LRU-eviction behavior."""
+    mock_fn = MagicMock()
+    with (
+        patch("parakeet_rocm.models.parakeet._get_cached_model", mock_fn),
+        patch("parakeet_rocm.models.parakeet._release_gpu_allocator_memory") as mock_release,
+    ):
+        clear_model_cache(release_allocator=False)
+    mock_fn.cache_clear.assert_called_once()
+    mock_release.assert_not_called()

--- a/tests/unit/test_srt_quality.py
+++ b/tests/unit/test_srt_quality.py
@@ -22,8 +22,20 @@ def test_compute_srt_quality_empty_segments() -> None:
     assert metrics["srt_length"] == 0
 
 
-def test_compute_srt_quality_basic_metrics() -> None:
+def test_compute_srt_quality_basic_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
     """compute_srt_quality should compute averages and readability rates."""
+    # Pin the thresholds this test asserts against: they are read from the
+    # environment at import time, so an ambient `.env` (e.g.
+    # MIN_SEGMENT_DURATION_SEC=1.5, MAX_CPS=14) would otherwise flip the rates.
+    import parakeet_rocm.formatting.srt_quality as srt_quality_mod
+
+    monkeypatch.setattr(srt_quality_mod, "MIN_SEGMENT_DURATION_SEC", 0.5)
+    monkeypatch.setattr(srt_quality_mod, "MAX_SEGMENT_DURATION_SEC", 7.0)
+    monkeypatch.setattr(srt_quality_mod, "MIN_CPS", 10.0)
+    monkeypatch.setattr(srt_quality_mod, "MAX_CPS", 22.0)
+    monkeypatch.setattr(srt_quality_mod, "MAX_LINE_CHARS", 42)
+    monkeypatch.setattr(srt_quality_mod, "MAX_LINES_PER_BLOCK", 2)
+
     segments = [
         {"start": 0.0, "end": 1.0, "text": "hello world"},
         {"start": 1.0, "end": 2.0, "text": "this is a longer line"},

--- a/tests/unit/test_transcription_utils.py
+++ b/tests/unit/test_transcription_utils.py
@@ -29,9 +29,18 @@ class TestConfigureEnvironment:
         assert os.environ.get("NEMO_LOG_LEVEL") == "INFO"
         assert os.environ.get("TRANSFORMERS_VERBOSITY") == "info"
 
-    def test_configure_environment_verbose_disabled(self) -> None:
+    def test_configure_environment_verbose_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test non-verbose mode sets ERROR logging."""
-        # Arrange & Act
+        # Arrange
+        # Pin the project defaults: they are read from the environment at
+        # import time, so an ambient `.env` (e.g. TRANSFORMERS_VERBOSITY=error)
+        # would otherwise change what non-verbose mode resets to.
+        import parakeet_rocm.utils.constant as constant_mod
+
+        monkeypatch.setattr(constant_mod, "NEMO_LOG_LEVEL", "ERROR")
+        monkeypatch.setattr(constant_mod, "TRANSFORMERS_VERBOSITY", "ERROR")
+
+        # Act
         configure_environment(verbose=False)
 
         # Assert

--- a/tests/unit/test_utils_watch.py
+++ b/tests/unit/test_utils_watch.py
@@ -419,3 +419,196 @@ def test_watch_cooperative_sigint_shutdown(
 
     # The stop event must be cleared after exit (ready for reuse)
     assert not _stop_event.is_set()
+
+
+@patch("parakeet_rocm.utils.watch.time.monotonic")
+@patch("parakeet_rocm.utils.watch.resolve_input_paths")
+@patch("parakeet_rocm.utils.watch.unload_model_to_cpu")
+@patch("parakeet_rocm.utils.watch.clear_model_cache")
+def test_watch_idle_unload_uses_cli_selected_model(
+    mock_clear_cache: MagicMock,
+    mock_unload: MagicMock,
+    mock_resolve: MagicMock,
+    mock_monotonic: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Watcher idle cleanup offloads the CLI-selected model, not the default.
+
+    Regression test for the case where ``--model`` differs from
+    ``PARAKEET_MODEL_NAME``: idle unload must pass the selected model name
+    so the model that is actually cached is moved off the GPU.
+    """
+    from parakeet_rocm.utils.constant import IDLE_UNLOAD_TIMEOUT_SEC
+
+    mock_monotonic.side_effect = [0.0, IDLE_UNLOAD_TIMEOUT_SEC + 1.0]
+    mock_resolve.return_value = []
+    transcribe_mock = MagicMock()
+
+    with patch("time.sleep", side_effect=KeyboardInterrupt()):
+        try:
+            watch_and_transcribe(
+                patterns=[tmp_path],
+                transcribe_fn=transcribe_mock,
+                poll_interval=0.1,
+                output_dir=tmp_path,
+                output_format="txt",
+                output_template="{filename}",
+                model_name="custom/model-x",
+                verbose=False,
+            )
+        except KeyboardInterrupt:
+            pass
+
+    mock_unload.assert_called_once_with("custom/model-x")
+
+
+@patch("parakeet_rocm.utils.watch.time.monotonic")
+@patch("parakeet_rocm.utils.watch.resolve_input_paths")
+@patch("parakeet_rocm.utils.watch.unload_model_to_cpu")
+@patch("parakeet_rocm.utils.watch.clear_model_cache")
+def test_watch_idle_unload_defaults_to_configured_model(
+    mock_clear_cache: MagicMock,
+    mock_unload: MagicMock,
+    mock_resolve: MagicMock,
+    mock_monotonic: MagicMock,
+    tmp_path: Path,
+) -> None:
+    """Default-model watch behavior remains unchanged (regression guard)."""
+    from parakeet_rocm.utils import watch as watch_module
+    from parakeet_rocm.utils.constant import IDLE_UNLOAD_TIMEOUT_SEC
+
+    # Reference the binding the watcher module actually uses; a plain
+    # ``from constant import PARAKEET_MODEL_NAME`` here would re-read the
+    # constant module and break if another test reloaded it with a patched
+    # environment (order-dependent test pollution).
+    parakeet_model_name = watch_module.PARAKEET_MODEL_NAME
+
+    mock_monotonic.side_effect = [0.0, IDLE_UNLOAD_TIMEOUT_SEC + 1.0]
+    mock_resolve.return_value = []
+    transcribe_mock = MagicMock()
+
+    with patch("time.sleep", side_effect=KeyboardInterrupt()):
+        try:
+            watch_and_transcribe(
+                patterns=[tmp_path],
+                transcribe_fn=transcribe_mock,
+                poll_interval=0.1,
+                output_dir=tmp_path,
+                output_format="txt",
+                output_template="{filename}",
+                verbose=False,
+            )
+        except KeyboardInterrupt:
+            pass
+
+    mock_unload.assert_called_once_with(parakeet_model_name)
+
+
+@patch("parakeet_rocm.utils.watch.time.monotonic")
+@patch("parakeet_rocm.utils.watch.resolve_input_paths")
+@patch("parakeet_rocm.utils.watch.unload_model_to_cpu")
+@patch("parakeet_rocm.utils.watch.clear_model_cache")
+def test_watch_idle_clear_failure_does_not_mark_complete(
+    mock_clear_cache: MagicMock,
+    mock_unload: MagicMock,
+    mock_resolve: MagicMock,
+    mock_monotonic: MagicMock,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Idle cleanup failure must not be reported as complete.
+
+    If clearing the model cache raises, the watcher stays healthy and the
+    "cleared" state is not marked done, so the next idle poll retries the
+    cleanup instead of silently skipping it.
+    """
+    from parakeet_rocm.utils.constant import IDLE_CLEAR_TIMEOUT_SEC
+
+    mock_monotonic.side_effect = [
+        0.0,
+        IDLE_CLEAR_TIMEOUT_SEC + 1.0,
+        IDLE_CLEAR_TIMEOUT_SEC + 2.0,
+        IDLE_CLEAR_TIMEOUT_SEC + 3.0,
+    ]
+    mock_resolve.return_value = []
+    mock_clear_cache.side_effect = [RuntimeError("boom"), None]
+    transcribe_mock = MagicMock()
+
+    call_count = 0
+
+    def mock_sleep(*_args: object) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 2:
+            raise KeyboardInterrupt()
+
+    with patch("time.sleep", side_effect=mock_sleep):
+        try:
+            watch_and_transcribe(
+                patterns=[tmp_path],
+                transcribe_fn=transcribe_mock,
+                poll_interval=0.1,
+                output_dir=tmp_path,
+                output_format="txt",
+                output_template="{filename}",
+                verbose=False,
+            )
+        except KeyboardInterrupt:
+            pass
+
+    # First clear attempt failed, second attempt (retry poll) succeeded.
+    assert mock_clear_cache.call_count == 2
+    captured = capsys.readouterr()
+    assert "Failed to clear model cache - will retry" in captured.err
+
+
+@patch("parakeet_rocm.utils.watch.time.monotonic")
+@patch("parakeet_rocm.utils.watch.resolve_input_paths")
+@patch("parakeet_rocm.utils.watch.unload_model_to_cpu")
+@patch("parakeet_rocm.utils.watch.clear_model_cache")
+def test_watch_idle_unload_failure_does_not_mark_complete(
+    mock_clear_cache: MagicMock,
+    mock_unload: MagicMock,
+    mock_resolve: MagicMock,
+    mock_monotonic: MagicMock,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A failed idle offload must not be reported as complete."""
+    from parakeet_rocm.utils.constant import IDLE_UNLOAD_TIMEOUT_SEC
+
+    mock_monotonic.side_effect = [
+        0.0,
+        IDLE_UNLOAD_TIMEOUT_SEC + 1.0,
+        IDLE_UNLOAD_TIMEOUT_SEC + 2.0,
+        IDLE_UNLOAD_TIMEOUT_SEC + 3.0,
+    ]
+    mock_resolve.return_value = []
+    mock_unload.side_effect = [RuntimeError("boom"), None]
+    transcribe_mock = MagicMock()
+
+    call_count = 0
+
+    def mock_sleep(*_args: object) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count >= 2:
+            raise KeyboardInterrupt()
+
+    with patch("time.sleep", side_effect=mock_sleep):
+        try:
+            watch_and_transcribe(
+                patterns=[tmp_path],
+                transcribe_fn=transcribe_mock,
+                poll_interval=0.1,
+                output_dir=tmp_path,
+                output_format="txt",
+                output_template="{filename}",
+                verbose=False,
+            )
+        except KeyboardInterrupt:
+            pass
+
+    assert mock_unload.call_count == 2
+    captured = capsys.readouterr()
+    assert "Failed to offload" in captured.err

--- a/tests/unit/test_utils_watch.py
+++ b/tests/unit/test_utils_watch.py
@@ -425,7 +425,7 @@ def test_watch_cooperative_sigint_shutdown(
 @patch("parakeet_rocm.utils.watch.resolve_input_paths")
 @patch("parakeet_rocm.utils.watch.unload_model_to_cpu")
 @patch("parakeet_rocm.utils.watch.clear_model_cache")
-def test_watch_idle_unload_uses_cli_selected_model(
+def test_watch_and_transcribe__forwards_cli_selected_model_to_idle_unload(
     mock_clear_cache: MagicMock,
     mock_unload: MagicMock,
     mock_resolve: MagicMock,
@@ -466,7 +466,7 @@ def test_watch_idle_unload_uses_cli_selected_model(
 @patch("parakeet_rocm.utils.watch.resolve_input_paths")
 @patch("parakeet_rocm.utils.watch.unload_model_to_cpu")
 @patch("parakeet_rocm.utils.watch.clear_model_cache")
-def test_watch_idle_unload_defaults_to_configured_model(
+def test_watch_and_transcribe__unloads_configured_model_by_default(
     mock_clear_cache: MagicMock,
     mock_unload: MagicMock,
     mock_resolve: MagicMock,
@@ -508,7 +508,7 @@ def test_watch_idle_unload_defaults_to_configured_model(
 @patch("parakeet_rocm.utils.watch.resolve_input_paths")
 @patch("parakeet_rocm.utils.watch.unload_model_to_cpu")
 @patch("parakeet_rocm.utils.watch.clear_model_cache")
-def test_watch_idle_clear_failure_does_not_mark_complete(
+def test_watch_and_transcribe__retries_idle_clear_when_eviction_fails(
     mock_clear_cache: MagicMock,
     mock_unload: MagicMock,
     mock_resolve: MagicMock,
@@ -518,9 +518,11 @@ def test_watch_idle_clear_failure_does_not_mark_complete(
 ) -> None:
     """Idle cleanup failure must not be reported as complete.
 
-    If clearing the model cache raises, the watcher stays healthy and the
-    "cleared" state is not marked done, so the next idle poll retries the
-    cleanup instead of silently skipping it.
+    When cache eviction fails (``clear_model_cache`` returns ``False``),
+    the watcher stays healthy and the "cleared" state is not marked done,
+    so the next idle poll retries the cleanup instead of silently skipping
+    it. This mirrors the real failure mode: ``clear_model_cache()`` never
+    raises, it reports failure via its bool return value.
     """
     from parakeet_rocm.utils.constant import IDLE_CLEAR_TIMEOUT_SEC
 
@@ -531,7 +533,9 @@ def test_watch_idle_clear_failure_does_not_mark_complete(
         IDLE_CLEAR_TIMEOUT_SEC + 3.0,
     ]
     mock_resolve.return_value = []
-    mock_clear_cache.side_effect = [RuntimeError("boom"), None]
+    # Real failure mode: clear_model_cache() returns False on eviction
+    # failure instead of raising; the second (retry) call succeeds.
+    mock_clear_cache.side_effect = [False, True]
     transcribe_mock = MagicMock()
 
     call_count = 0
@@ -566,7 +570,7 @@ def test_watch_idle_clear_failure_does_not_mark_complete(
 @patch("parakeet_rocm.utils.watch.resolve_input_paths")
 @patch("parakeet_rocm.utils.watch.unload_model_to_cpu")
 @patch("parakeet_rocm.utils.watch.clear_model_cache")
-def test_watch_idle_unload_failure_does_not_mark_complete(
+def test_watch_and_transcribe__retries_idle_unload_on_failure(
     mock_clear_cache: MagicMock,
     mock_unload: MagicMock,
     mock_resolve: MagicMock,

--- a/tests/unit/test_webui_app.py
+++ b/tests/unit/test_webui_app.py
@@ -191,8 +191,9 @@ def _install_fake_model_accessors(monkeypatch: pytest.MonkeyPatch) -> types.Modu
     def unload_model_to_cpu() -> None:
         mod.unload_model_to_cpu_called = True
 
-    def clear_model_cache() -> None:
+    def clear_model_cache() -> bool:
         mod.clear_model_cache_called = True
+        return True
 
     mod.unload_model_to_cpu = unload_model_to_cpu
     mod.clear_model_cache = clear_model_cache


### PR DESCRIPTION
## Summary

- `watch_and_transcribe()` gains a `model_name` argument (default `PARAKEET_MODEL_NAME`); `_setup_watch_mode()` forwards the CLI-selected `--model` so idle cleanup offloads the model that is actually cached, not the configured default.
- `clear_model_cache()` now runs a GC pass and releases PyTorch's CUDA/ROCm caching-allocator memory after dropping cached references. This is the reuse-correct seam: the same "evicted refs but parked allocator memory" defect existed at all three idle-cleanup call sites (watch, API idle thread, webui), so the release lives in the model layer and every caller benefits.
- Idle flags (`unloaded` / `cleared`) are only set on success now — in **both** the watch loop and the WebUI idle-offload thread (`webui/app.py::_start_idle_offload_thread`, also wired into the API app). A failed cleanup logs a warning and retries on the next poll instead of being silently marked complete. The WebUI worker also checks the `clear_model_cache()` bool return instead of discarding it.
- `_cleanup_models()` no longer duplicates `gc.collect()`/`torch.cuda.empty_cache()` — the allocator release lives in `clear_model_cache()`.

Fixes #50

## Verification

- `scripts/local-ci.sh`: **fully green** — ruff check, ruff format, **390 passed / 3 skipped**, 86% total coverage.
- Retry tests exercise the real failure mode (`clear_model_cache()` returning `False`, not a fabricated exception); bool contract asserted directly in `test_models_parakeet.py`.
- WebUI/API test fakes aligned with the real `bool` return of `clear_model_cache()`.

GPU verification of actual VRAM release pending on the ROCm host.

## Notes for reviewers

- `clear_model_cache()` skips the allocator release when the LRU eviction itself fails (guarded by `test_clear_model_cache_skips_release_when_cache_clear_fails`).
- `release_allocator=False` opt-out preserves the old pure-eviction behavior for callers that manage their own release.
- Known follow-up (out of scope): the WebUI does not pass a selected model name to `unload_model_to_cpu()`, so only the default model is offloaded on idle — flagged in the review-findings comment as Bug 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Watch mode now consistently uses the selected speech model, including during idle cleanup.
  * Failed model unloading or cache cleanup is reported and retried instead of being marked complete — in both the watch loop and the WebUI idle-offload thread.
  * Cache clearing now releases accelerator memory and safely handles cleanup failures.

* **Tests**
  * Added coverage for model selection, idle cleanup retries, CPU-only operation, and allocator release behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->